### PR TITLE
[WIP] Preserving bitrate during transcoding

### DIFF
--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -113,38 +113,38 @@ def transcode_video_command(track, output_playlist_name, targs, use_playlist):
         cmd.extend(playlist_cmd)
 
     # video settings
-    if 'video' in targs and 'codec' in targs['video']:
+    if targs.get('video', {}).get('codec') is not None:
         vcodec = targs['video']['codec']
         cmd.append("-c:v")
         cmd.append(codecs.get_video_encoder(vcodec))
 
-    if 'frame_rate' in targs:
+    if targs.get('frame_rate') is not None:
         fps = str(targs['frame_rate'])
         cmd.append("-r")
         cmd.append(fps)
 
-    if 'video' in targs and 'bitrate' in targs['video']:
+    if targs.get('video', {}).get('bitrate') is not None:
         vbitrate = targs['video']['bitrate']
         cmd.append("-b:v")
         cmd.append(vbitrate)
 
     # audio settings
-    if 'audio' in targs and 'codec' in targs['audio']:
+    if targs.get('audio', {}).get('codec') is not None:
         acodec = targs['audio']['codec']
         cmd.append("-c:a")
         cmd.append(codecs.get_audio_encoder(acodec))
 
-    if 'audio' in targs and 'bitrate' in targs['audio']:
+    if targs.get('audio', {}).get('bitrate') is not None:
         abitrate = targs['audio']['bitrate']
         cmd.append("-b:a")
         cmd.append(abitrate)
 
-    if 'resolution' in targs:
+    if targs.get('resolution') is not None:
         res = targs['resolution']
         cmd.append("-vf")
         cmd.append("scale={}:{}".format(res[0], res[1]))
 
-    if 'scaling_alg' in targs:
+    if targs.get('scaling_alg') is not None:
         scale = targs["scaling_alg"]
         cmd.append("-sws_flags")
         cmd.append("{}".format(scale))

--- a/ffmpeg_tools/meta.py
+++ b/ffmpeg_tools/meta.py
@@ -41,6 +41,14 @@ def get_format(metadata):
     return metadata["format"]["format_name"]
 
 
+def get_video_bitrates(metadata):
+    return [
+        stream_metadata.get("bit_rate")
+        for stream_metadata in metadata["streams"]
+        if stream_metadata["codec_type"] == "video"
+    ]
+
+
 def create_params(vformat, resolution, vcodec, acodec=None,
                   frame_rate=None, video_bitrate=None,
                   audio_bitrate=None, scaling_algorithm=None):
@@ -50,7 +58,7 @@ def create_params(vformat, resolution, vcodec, acodec=None,
 
     # Video parameters
     args["video"] = dict()
-    
+
     args["resolution"] = resolution
     args["video"]["codec"] = vcodec
 
@@ -62,13 +70,13 @@ def create_params(vformat, resolution, vcodec, acodec=None,
 
     if frame_rate:
         args["frame_rate"] = frame_rate
-        
+
     # Audio parameters
     args["audio"] = dict()
 
     if acodec:
         args["audio"]["codec"] = acodec
-    
+
     if audio_bitrate:
         args["audio"]["bitrate"] = audio_bitrate
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,7 +12,7 @@ class TestCommands(TestCase):
 
         input_video = "tests/resources/ForBiggerBlazes-[codec=h264].mp4"
         output_video = os.path.join(tempfile.gettempdir(), "ForBiggerBlazes-[codec=h265].mp4")
-        
+
         if os.path.exists(output_video):
             os.remove(output_video)
 
@@ -20,6 +20,58 @@ class TestCommands(TestCase):
 
         assert os.path.exists(output_video)
 
+    def test_transcoding_should_preserve_bitrate(self):
+        params = ffmpeg.meta.create_params("mkv", [640, 400], "mpeg4")
+        assert 'bitrate' not in params.get("video", {})
+
+        input_video = "tests/resources/ForBiggerBlazes-[codec=h264].mp4"
+        output_video = os.path.join(tempfile.gettempdir(), "ForBiggerBlazes-[codec=h264].mp4")
+
+        if os.path.exists(output_video):
+            os.remove(output_video)
+
+        ffmpeg.commands.transcode_video(input_video, params, output_video, use_playlist=False)
+        self.assertTrue(os.path.exists(output_video))
+
+        input_bitrate_strings = ffmpeg.meta.get_video_bitrates(ffmpeg.meta.get_metadata(input_video))
+        output_bitrate_strings = ffmpeg.meta.get_video_bitrates(ffmpeg.meta.get_metadata(output_video))
+        assert len(input_bitrate_strings) == 1 and len(output_bitrate_strings) == 1
+
+        input_bitrate = int(input_bitrate_strings[0])
+        output_bitrate = int(output_bitrate_strings[0])
+
+        # FIXME: I'm accepting a 10% difference as a match here but from my limited
+        # experiments I've seen that you can't reliably get the bitrate you want.
+        # The result often varies (sometimes only a little, sometimes a lot) from what you request.
+        self.assertAlmostEqual(output_bitrate, input_bitrate, delta=input_bitrate * 0.10)
+
+    def test_transcoding_should_not_preserve_bitrate_if_set_to_none(self):
+        # NOTE: There's no way to get a structure like this from create_params().
+        # It treats None the same way as a missing keys.
+        params = {
+            "format": "mkv",
+            "video": {
+                "codec": "mpeg4",
+                "bitrate": None,
+            }
+        }
+        input_video = "tests/resources/ForBiggerBlazes-[codec=h264].mp4"
+        output_video = os.path.join(tempfile.gettempdir(), "ForBiggerBlazes-[codec=h264].mp4")
+
+        if os.path.exists(output_video):
+            os.remove(output_video)
+
+        ffmpeg.commands.transcode_video(input_video, params, output_video, use_playlist=False)
+        self.assertTrue(os.path.exists(output_video))
+
+        input_bitrate_strings = ffmpeg.meta.get_video_bitrates(ffmpeg.meta.get_metadata(input_video))
+        output_bitrate_strings = ffmpeg.meta.get_video_bitrates(ffmpeg.meta.get_metadata(output_video))
+        assert len(input_bitrate_strings) == 1 and len(output_bitrate_strings) == 1
+
+        input_bitrate = int(input_bitrate_strings[0])
+        output_bitrate = int(output_bitrate_strings[0])
+
+        self.assertNotAlmostEqual(output_bitrate, input_bitrate, delta=input_bitrate * 0.15)
 
     def test_get_video_length(self):
         input_video = "tests/resources/ForBiggerBlazes-[codec=h264].mp4"

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -32,6 +32,7 @@ example_metadata = {
             "time_base": "1/1000",
             "start_pts": 7,
             "start_time": "0.007000",
+            "bit_rate": "1135146",
             "disposition": {
                 "default": 1,
                 "dub": 0,
@@ -120,4 +121,5 @@ class TestMetadata(object):
     def test_get_metadata_invalid_path(self):
         assert(ffmpeg.meta.get_metadata("blabla") == {})
 
-
+    def test_get_video_bitrates(self):
+        assert ffmpeg.meta.get_video_bitrates(example_metadata) == ["1135146"]


### PR DESCRIPTION
This pull request adds bitrate detection to transcoding. The value is obtained from the `bit_rate` field of the first video stream and then inserted into `targs["video"]["bitrate"]` - but only if the caller did not specify the parameter himself.

Metadata is obtained by running `ffprobe` (`get_metadata_json()`). My change makes it possible to opt out of the auto detection by explicitly setting the bitrate to `None` in `targs`.

1) ffprobe reports several bitrate values: `bit_rate` field is usually present in the format metadata and also in the metadata of each video and audio stream. From what I've seen the value in the format metadata is roughly equal to the sum of the values from streams (differences are on the order of 1 kbps). I'm using the value from the video stream in the implementation.
2) I'm not handling the case of a file with no video stream. The code will crash when trying to access a non-existent list item.
3) If there are multiple video streams (rare but technically possible, e.g. in MKV) I'm just printing a warning to stderr and disabling autodetection. You might want to report an error instead.
4) I've added a sample bitrate value to the hard-coded test data. I considered adding another set of data with less missing values instead but I'm not sure if that's how you want the tests to work. Since I only need this single value, I've decided that it's not a big enough reason to significantly change the test organization. It might not be consistent with the rest of values,  but the current tests do not seem to require consistent data anyway. They only check individual values.
5) **The biggest problem**: I'm not certain that we can really preserve bitrate in most cases. The test I added passes because the difference is smaller than 10% in this particular case but I've seen much bigger differences in arbitrary conversions. I don't know if we can rely on the difference being that small in general. See my experiment details below.
6) Different codecs probably support different range of bitrates. And different bitrates represent different levels of quality (HEVC will definitely look better than MJPEG at the same bitrate). So preserving bitrate when we do codec conversion may not be desired by the user. This pull request does not address this.
7) I think that we'll have to take resolution into account. E.g. when resizing from 320x240 to 640x480, there's 4x more uncompressed data per second. It might not be full 4x after compression but still, preserving bitrate in that case will probably mean decreasing quality up to 4 times. Again, this pull request does not address this problem in its current form. Hence the `[WIP]` marker.

In short: I've implemented it and it passes my tests but I think this feature requires more research/expreriments. But that's up to you.

### Experimenting with `-b:v`
I've done some rough tests on the video file included in the repository (`ForBiggerBlazes-[codec=h264].mp4`, conversion to H.264/AVI with `libxvid` and scaling from 1280x720 to to 640x400) and here's what I see in the `bit_rate` fields in metadata for various `-b:v` inputs:

| `-b:v`    | format `bit_rate` | video `bit_rate` | audio `bit_rate` |
|-----------|-------------------|------------------|------------------|
| 100000 | 366580 | 232532 | 129091 |
| 200000 | 392969 | 258977 | 129091 |
| 300000 | 461803 | 327957 | 129091 |
| 400000 | 539512 | 405832 | 129091 |
| 500000 | 610889 | 477361 | 129091 |
| 600000 | 676253 | 542865 | 129091 |
| 700000 | 733673 | 600407 | 129091 |
| 800000 | 796707 | 663575 | 129091 |
| 900000 | 850129 | 717111 | 129091 |
| 1000000 | 906112 | 773213 | 129091 |
| 2000000 | 1322490 | 1190478 | 129091 |
| 3000000 | 1588284 | 1456839 | 129091 |
| 4000000 | 1685109 | 1553870 | 129091 |
| 5000000 | 1696024 | 1564809 | 129091 |
| 6000000 | 1696024 | 1564809 | 129091 |
| 7000000 | 1695759 | 1564543 | 129091 |
| 8000000 | 1695660 | 1564444 | 129091 |
| 9000000 | 1696271 | 1565056 | 129091 |
| 10000000 | 1695912 | 1564697 | 129091 |

This is not really a big sample and transcoding parameters are kinda random but that's simply what I got when I tried a quick experiment with different bitrates and other parameters same as in my unit test. Something more representative would require a bit more effort and I was trying to to go too deep into that for now.

As you can see:
- There seems to be a limit on how low or high we can go (~233-1565 kbps for this codec with these parameters, though it's not an exact value)
- Even within the limits the bitrate is always different than the value we request. And the difference does not seem consistent. Can be both quite small and very large.
- Up to a point the resulting bitrate is always too high. After that it's consistently too low.
    - I don't know if this point is constant but it is definitely **not** equal to the bitrate of the input file. The video bitrate for this file is 1135146 bps.

Some thoughts on the matter:
1) I don't know yet what causes these discrepancies. [Limiting the output bitrate](https://trac.ffmpeg.org/wiki/Limiting%20the%20output%20bitrate) suggests that bitrate variation can be decreased by using the `-bufsize` option. Our problem is with the average bitrate though so I don't know if this would help. This requires more experimentation.
2) Maybe the `-b:v` parameter is applied before scaling and video filters can affect the bitrate after that?
3) For the purpose of preserving bitrate we don't really need to be able to use values from outside of the supported range. We only need to be able to keep it the same as in the original file. For this particular file the difference when I requested the original bitrate is small (less than 10%). If that's generally true, we might be able to still use this solution. But it requires testing on more files and with a wider range of codecs.