### PR TITLE
Switch to 'ffmpeg segment' and 'concat demuxer' in split and merge commands

### DIFF
--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -74,15 +74,22 @@ def split(input_file, output_list_file, segment_time):
 
 
 def split_video_command(input_file, output_list_file, segment_time):
+    (_, input_filename) = os.path.split(input_file)
+    (input_basename, input_extension) = os.path.splitext(input_filename)
+
+    (output_dir, _) = os.path.split(output_list_file)
+
     cmd = [
         FFMPEG_COMMAND,
         "-nostdin",
         "-i", input_file,
-        "-hls_time", "{}".format(segment_time),
-        "-hls_list_size", "0",
-        "-c", "copy",
-        "-mpegts_copyts", "1",
-        output_list_file
+        "-codec", "copy",
+        "-f", "segment",
+        "-reset_timestamps", "1",
+        "-segment_time", f"{segment_time}",
+        "-segment_list_type", "m3u8",
+        "-segment_list", output_list_file,
+        f"{output_dir}/{input_basename}_%d{input_extension}",
     ]
 
     return cmd, output_list_file
@@ -163,9 +170,10 @@ def merge_videos_command(input_file, output):
     cmd = [
         FFMPEG_COMMAND,
         "-nostdin",
+        "-f", "concat",
+        "-safe", "0",
         "-i", input_file,
         "-c", "copy",
-        "-mpegts_copyts", "1",
         output
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='ffmpeg-tools',
-    version='0.11.0',
+    version='0.12.0',
     description="Tools for using ffmpeg functionalities in python.",
     url='https://github.com/golemfactory/ffmpeg-tools',
     maintainer='The Golem Team',


### PR DESCRIPTION
This pull request changes the methods used for splitting and merging videos. Now the `split` command is using `ffmpeg -f segment` instead of `-hls_time`. This has the advantage of being able to split non-MPEG files. The `merge` command is now using the [`concat` demuxer](https://trac.ffmpeg.org/wiki/Concatenate#demuxer) (`ffmpeg -f concat`) instead of relying on the concatenation of HLS playlists.

### Backwards compatibilty
The pull request does not change signatures of `split_video()` and `merge_video()` but there's a change in the interpretation of the `input_file` and `output` parameters of `merge_video()` that will require changes in the calling code. The function used to expect a .m3u playlist as input but the `concat` demuxer only works with [ffconcat files](https://www.ffmpeg.org/ffmpeg-formats.html#Syntax). The output used to be a playlist as well but now it should be the path fo the resulting video file.

### Tests
**NOTE**: This pull request does not add any unit tests. When I wrote it originally, the code was a part of Golem and there was no easy way to add and run them. It was covered only by existing transcoding tests.

Now that it's been moved to a separate repository it's possible to add some tests. Please let me know if you want them. I'd prefer to do them in a separate pull request though.