### PR TITLE
Extract and replace commands

### DIFF
--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -20,6 +20,10 @@ class CommandFailed(Exception):
         self.error_code = error_code
 
 
+class InvalidArgument(Exception):
+    pass
+
+
 def flatten_list(list_of_lists):
     return [item for sublist in list_of_lists for item in sublist]
 
@@ -279,7 +283,12 @@ def replace_streams_command(input_file,
             - `d` - data streams.
             - `t` - attachments.
     """
-    assert stream_type in ['v', 'V', 'a', 's', 'd', 't']
+    VALID_STREAM_TYPES = {'v', 'V', 'a', 's', 'd', 't'}
+    if stream_type not in VALID_STREAM_TYPES:
+        raise InvalidArgument(
+            f"Invalid value of 'stream_type'. "
+            f"Should be one of: {', '.join(VALID_STREAM_TYPES)}"
+        )
 
     cmd = [
         FFMPEG_COMMAND,

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -289,6 +289,7 @@ def replace_streams_command(input_file,
         "-map", f"1:{stream_type}",
         "-map", "0",
         "-map", f"-0:{stream_type}",
+        "-copy_unknown",
         "-codec", "copy",
         output_file,
     ]

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -74,15 +74,22 @@ def split(input_file, output_list_file, segment_time):
 
 
 def split_video_command(input_file, output_list_file, segment_time):
+    (_, input_filename) = os.path.split(input_file)
+    (input_basename, input_extension) = os.path.splitext(input_filename)
+
+    (output_dir, _) = os.path.split(output_list_file)
+
     cmd = [
         FFMPEG_COMMAND,
         "-nostdin",
         "-i", input_file,
-        "-hls_time", "{}".format(segment_time),
-        "-hls_list_size", "0",
-        "-c", "copy",
-        "-mpegts_copyts", "1",
-        output_list_file
+        "-codec", "copy",
+        "-f", "segment",
+        "-reset_timestamps", "1",
+        "-segment_time", f"{segment_time}",
+        "-segment_list_type", "m3u8",
+        "-segment_list", output_list_file,
+        f"{output_dir}/{input_basename}_%d{input_extension}",
     ]
 
     return cmd, output_list_file
@@ -163,9 +170,10 @@ def merge_videos_command(input_file, output):
     cmd = [
         FFMPEG_COMMAND,
         "-nostdin",
+        "-f", "concat",
+        "-safe", "0",
         "-i", input_file,
         "-c", "copy",
-        "-mpegts_copyts", "1",
         output
     ]
 

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -290,7 +290,8 @@ def replace_streams_command(input_file,
         "-map", "0",
         "-map", f"-0:{stream_type}",
         "-copy_unknown",
-        "-codec", "copy",
+        "-c:v", "copy",
+        "-c:d", "copy",
         output_file,
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name='ffmpeg-tools',
-    version='0.11.0',
+    version='0.12.0',
     description="Tools for using ffmpeg functionalities in python.",
     url='https://github.com/golemfactory/ffmpeg-tools',
     maintainer='The Golem Team',

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -12,7 +12,7 @@ class TestCommands(TestCase):
 
         input_video = "tests/resources/ForBiggerBlazes-[codec=h264].mp4"
         output_video = os.path.join(tempfile.gettempdir(), "ForBiggerBlazes-[codec=h265].mp4")
-        
+
         if os.path.exists(output_video):
             os.remove(output_video)
 
@@ -31,3 +31,37 @@ class TestCommands(TestCase):
     def test_failed_command(self):
         with self.assertRaises(ffmpeg.commands.CommandFailed):
             ffmpeg.commands.get_video_len("bla")
+
+
+    def test_replace_streams_command(self):
+        command = ffmpeg.commands.replace_streams_command(
+            "tests/resources/ForBiggerBlazes-[codec=h264].mp4",
+            "tests/resources/ForBiggerBlazes-[codec=h264][video-only].mkv",
+            "tests/resources/ForBiggerBlazes-[codec=h264].mkv",
+            "v",
+        )
+
+        expected_command = [
+            "ffmpeg",
+            "-nostdin",
+            "-i", "tests/resources/ForBiggerBlazes-[codec=h264].mp4",
+            "-i", "tests/resources/ForBiggerBlazes-[codec=h264][video-only].mkv",
+            "-map", "1:v",
+            "-map", "0",
+            "-map", "-0:v",
+            "-copy_unknown",
+            "-c:v", "copy",
+            "-c:d", "copy",
+            "tests/resources/ForBiggerBlazes-[codec=h264].mkv",
+        ]
+        self.assertEqual(command, expected_command)
+
+
+    def test_replace_streams_command_validates_stream_type(self):
+        with self.assertRaises(ffmpeg.commands.InvalidArgument):
+            ffmpeg.commands.replace_streams_command(
+                "tests/resources/ForBiggerBlazes-[codec=h264].mp4",
+                "tests/resources/ForBiggerBlazes-[codec=h264][video-only].mkv",
+                "tests/resources/ForBiggerBlazes-[codec=h264].mkv",
+                "v:1",
+            )


### PR DESCRIPTION
This pull request adds two new commands:
- `extract_streams` which creates a new video file containing only selected streams from the input (e.g. "all video streams" or "first data stream and second audio stream").
- `replace_streams` which can create a new video file with all streams of a specific type replaced with streams of the same type from another video file.

The commands can be used to get a file containing only video streams for processing, process that file and then combine the processed video with the other streams.

### Backwards compatibility
The patch does not change the API of existing commands.

### Dependencies
This pull request depends on #3 and should not be merged before it. The branch is on top of it.

**NOTE**: I have set the base branch of this pull request to `segment-split-and-concat-demuxer-merge` (#3) rather than `master`. Otherwise you would see changes from that branch here. The downside is that github now expects it to be merged into that base branch rather than into `master` and will simply close the pull request (instead or marking it as "merged") if you merge it into `master`. To prevent this please remember to change the base branch back to master before you merge.

### Tests
**NOTE**: This pull request does not add any unit tests. When I wrote it originally, the code was a part of Golem and there was no easy way to add and run them. It was covered only by existing transcoding tests.

Now that it's been moved to a separate repository it's possible to add some tests. Please let me know if you want them. I'd prefer to do them in a separate pull request though.