### PR TITLE
Remove m3u playlist support leftovers

### DIFF
--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -118,7 +118,7 @@ def split_video(input_file, output_dir, split_len):
     [_, filename] = os.path.split(input_file)
     [basename, _] = os.path.splitext(filename)
 
-    output_list_file = os.path.join(output_dir, basename + "_.m3u8")
+    output_list_file = os.path.join(output_dir, basename + "-segment-list.txt")
 
     split_list_file = split(input_file, output_list_file, split_len)
 
@@ -147,7 +147,7 @@ def split_video_command(input_file, output_list_file, segment_time):
         "-f", "segment",
         "-reset_timestamps", "1",
         "-segment_time", f"{segment_time}",
-        "-segment_list_type", "m3u8",
+        "-segment_list_type", "flat",
         "-segment_list", output_list_file,
         f"{output_dir}/{input_basename}_%d{input_extension}",
     ]

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -155,13 +155,12 @@ def split_video_command(input_file, output_list_file, segment_time):
     return cmd, output_list_file
 
 
-def transcode_video(track, targs, output, use_playlist):
-    cmd = transcode_video_command(track, output,
-                                  targs, use_playlist)
+def transcode_video(track, targs, output):
+    cmd = transcode_video_command(track, output, targs)
     exec_cmd(cmd)
 
 
-def transcode_video_command(track, output_playlist_name, targs, use_playlist):
+def transcode_video_command(track, output_file, targs):
     cmd = [
         FFMPEG_COMMAND,
         "-nostdin",
@@ -170,14 +169,6 @@ def transcode_video_command(track, output_playlist_name, targs, use_playlist):
         # input file
         "{}".format(track)
     ]
-
-    if use_playlist:
-        playlist_cmd = [
-            # It states that all entries from list should be processed
-            "-hls_list_size", "0",
-            "-copyts"
-        ]
-        cmd.extend(playlist_cmd)
 
     # video settings
     if 'video' in targs and 'codec' in targs['video']:
@@ -216,7 +207,7 @@ def transcode_video_command(track, output_playlist_name, targs, use_playlist):
         cmd.append("-sws_flags")
         cmd.append("{}".format(scale))
 
-    cmd.append("{}".format(output_playlist_name))
+    cmd.append("{}".format(output_file))
 
     return cmd
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -16,7 +16,7 @@ class TestCommands(TestCase):
         if os.path.exists(output_video):
             os.remove(output_video)
 
-        ffmpeg.commands.transcode_video(input_video, params, output_video, False)
+        ffmpeg.commands.transcode_video(input_video, params, output_video)
 
         assert os.path.exists(output_video)
 


### PR DESCRIPTION
This pull request removes the obsolete bits of code for handling .m3u playlists left over after #3 and #4:
- The `use_playlist` parameter. After #3 setting this parameter to `True` does not work but Golem was not using it anyway.
- The use of .m3u format in the split command. A flat text file with one path per line frees the caller from having to understand the .m3u format.

### Backwards compatibility
The change is not backwards compatible.

### Dependencies
This pull request depends on #4 and should not be merged before it. The branch is on top of it.

**NOTE**: I have set the base branch of this pull request to ` extract-and-replace-commands` (#4) rather than `master`. Otherwise you would see changes from that branch here. The downside is that github now expects it to be merged into that base branch rather than into `master` and will simply close the pull request (instead or marking it as "merged") if you merge it into `master`. To prevent this please remember to change the base branch back to master before you merge.

### Tests
**NOTE**: This pull request does not add any unit tests. When I wrote it originally, the code was a part of Golem and there was no easy way to add and run them. It was covered only by existing transcoding tests.

Now that it's been moved to a separate repository it's possible to add some tests. Please let me know if you want them. I'd prefer to do them in a separate pull request though.