### PR TITLE
Muxers and demuxers

### DIFF
--- a/ffmpeg_tools/codecs.py
+++ b/ffmpeg_tools/codecs.py
@@ -36,6 +36,7 @@ class VideoCodec(enum.Enum):
 class AudioCodec(enum.Enum):
     AAC = 'aac'
     MP3 = 'mp3'
+    OPUS = 'opus'
 
 
     # Normally enum throws ValueError, when initialization value is invalid.

--- a/ffmpeg_tools/codecs.py
+++ b/ffmpeg_tools/codecs.py
@@ -97,16 +97,14 @@ def get_audio_encoder(target_codec):
 
 
 def list_supported_video_conversions(codec):
-    try:
-        vcodec = VideoCodec(codec)
-        return vcodec.get_supported_conversions()
-    except:
+    if codec not in VideoCodec._value2member_map_:
         return []
+
+    return VideoCodec(codec).get_supported_conversions()
 
 
 def list_supported_audio_conversions(codec):
-    try:
-        acodec = AudioCodec(codec)
-        return acodec.get_supported_conversions()
-    except:
+    if codec not in AudioCodec._value2member_map_:
         return []
+
+    return AudioCodec(codec).get_supported_conversions()

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -35,9 +35,15 @@ class Container(enum.Enum):
         return Container(name.lower())
 
     def get_supported_video_codecs(self):
+        if self.value not in _CONTAINER_SUPPORTED_CODECS:
+            return []
+
         return _CONTAINER_SUPPORTED_CODECS[self.value]["videocodecs"]
 
     def get_supported_audio_codecs(self):
+        if self.value not in _CONTAINER_SUPPORTED_CODECS:
+            return []
+
         return _CONTAINER_SUPPORTED_CODECS[self.value]["audiocodecs"]
 
     def is_supported_video_codec(self, vcodec):
@@ -163,11 +169,10 @@ def is_supported(vformat):
 
 
 def list_supported_video_codecs(vformat):
-    try:
-        container = Container(vformat)
-        return container.get_supported_video_codecs()
-    except:
+    if vformat not in Container._value2member_map_:
         return []
+
+    return Container(vformat).get_supported_video_codecs()
 
 
 def is_supported_video_codec(vformat, codec):
@@ -175,11 +180,10 @@ def is_supported_video_codec(vformat, codec):
 
 
 def list_supported_audio_codecs(vformat):
-    try:
-        container = Container(vformat)
-        return container.get_supported_audio_codecs()
-    except:
+    if vformat not in Container._value2member_map_:
         return []
+
+    return Container(vformat).get_supported_audio_codecs()
 
 
 def is_supported_audio_codec(vformat, codec):

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -20,6 +20,7 @@ class Container(enum.Enum):
     # group of similar formats. We need to heve them listed
     # to allow them in validation functions.
     c_QUICK_TIME = "mov,mp4,m4a,3gp,3g2,mj2"
+    c_MATROSKA_WEBM = "matroska,webm"
 
 
     # Normally enum throws ValueError, when initialization value is invalid.
@@ -162,8 +163,14 @@ _QUICKTIME_CODECS = {
     )),
 }
 
+_MATROSKA_WEBM_CODECS = {
+    "videocodecs": list(set(_MKV_CODECS["videocodecs"] + _WEBM_CODECS["videocodecs"])),
+    "audiocodecs": list(set(_MKV_CODECS["audiocodecs"] + _WEBM_CODECS["audiocodecs"])),
+}
+
 
 _CONTAINER_SUPPORTED_CODECS = {
+    "matroska,webm": _MATROSKA_WEBM_CODECS,
     "mp4": _MP4_CODECS,
     "mov": _MOV_CODECS,
     "mkv": _MKV_CODECS,

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -6,19 +6,28 @@ from . import codecs
 
 
 class Container(enum.Enum):
-    c_F4V = "f4v"
-    c_3GP = "3gp"
-    c_3G2 = "3g2"
-    c_MP4 = 'mp4'
-    c_AVI = 'avi'
-    c_MKV = 'mkv'
-    c_MPEG = 'mpeg'
-    c_MOV = 'mov'
-    c_WEBM = "webm"
+    # The values below are **muxer** names, which means that they can be passed
+    # to ffmpeg using the -f option to specify the target format.
+    c_3G2 = "3g2"           # 3GP2 (3GPP2 file format) muxer
+    c_3GP = "3gp"           # 3GP (3GPP file format) muxer
+    c_AVI = "avi"           # AVI (Audio Video Interleaved) muxer
+    c_F4V = "f4v"           # F4V Adobe Flash Video muxer
+    c_MATROSKA = "matroska" # Matroska; .mkv extension muxer
+    c_MP4 = "mp4"           # MP4 (MPEG-4 Part 14) muxer
+    c_MPEG = "mpeg"         # MPEG-1 Systems / MPEG program stream muxer
+    c_MOV = "mov"           # QuickTime / MOV muxer
+    c_WEBM = "webm"         # WebM muxer
 
-    # Sometimes ffmpeg can't tell us precise format, but returns
-    # group of similar formats. We need to heve them listed
-    # to allow them in validation functions.
+    # Unfortunately ffprobe can't read muxer name back from an existing container.
+    # what it gives us instead is a **demuxer** name. In many cases those names
+    # are the same but there are significant exceptions. The values below are
+    # those exceptions. We need them to be able to validate the format of an
+    # input file but they won't work when used as tgarget formats.
+    #
+    # Note that while these names may simply look like a list of
+    # muxer names, they're not reliable that way. For example 'mov,mp4,m4a,3gp,3g2,mj2'
+    # covers also files created by the 'f4v' muxer. And `mpegts' is both a
+    # muxer and demuxer but the demuxer handles also files created by the 'svcd' muxer.
     c_QUICK_TIME_DEMUXER = "mov,mp4,m4a,3gp,3g2,mj2" # QuickTime / MOV
     c_MATROSKA_WEBM_DEMUXER = "matroska,webm"        # Matroska / WebM
 
@@ -170,14 +179,14 @@ _MATROSKA_WEBM_CODECS = {
 
 
 _CONTAINER_SUPPORTED_CODECS = {
-    "matroska,webm": _MATROSKA_WEBM_CODECS,
-    "mp4": _MP4_CODECS,
-    "mov": _MOV_CODECS,
-    "mkv": _MKV_CODECS,
-    "3gp": _3GP_CODECS,
     "3g2": _3GP_CODECS,
-    "mov,mp4,m4a,3gp,3g2,mj2": _QUICKTIME_CODECS,
+    "3gp": _3GP_CODECS,
     "avi": _AVI_CODECS,
+    "matroska": _MKV_CODECS,
+    "matroska,webm": _MATROSKA_WEBM_CODECS,
+    "mov": _MOV_CODECS,
+    "mp4": _MP4_CODECS,
+    "mov,mp4,m4a,3gp,3g2,mj2": _QUICKTIME_CODECS,
     "mpeg": _MPEG_CODECS,
     "webm": _WEBM_CODECS,
 }

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -82,17 +82,25 @@ class Container(enum.Enum):
         return list_supported_formats()
 
     def get_demuxer(self):
+        if self not in _DEMUXER_MAP:
+            return self.value
+
         return _DEMUXER_MAP[self].value
 
     def is_exclusive_demuxer(self):
         return self in _EXCLUSIVE_DEMUXERS
 
     def get_matching_muxers(self):
-        return {
+        muxers = {
             muxer
             for muxer, demuxer in _DEMUXER_MAP.items()
             if demuxer == self
         }
+
+        if self.is_exclusive_demuxer():
+            return muxers
+        else:
+            return muxers | {self}
 
 
 # This set containe demuxers that cannot be used as muxers in ffmpeg.
@@ -103,16 +111,15 @@ _EXCLUSIVE_DEMUXERS = {
 
 
 # This dictionary defines which ffmpeg demuxer handles files encoded by which
-# muxer.
+# muxer. If there's no entry for a particular demuxer, it means that it can
+# be used as a demuxer as well.
 _DEMUXER_MAP = {
     Container.c_3G2: Container.c_QUICK_TIME_DEMUXER,
     Container.c_3GP: Container.c_QUICK_TIME_DEMUXER,
-    Container.c_AVI: Container.c_AVI,
     Container.c_F4V: Container.c_QUICK_TIME_DEMUXER,
     Container.c_MATROSKA: Container.c_MATROSKA_WEBM_DEMUXER,
     Container.c_MOV: Container.c_QUICK_TIME_DEMUXER,
     Container.c_MP4: Container.c_QUICK_TIME_DEMUXER,
-    Container.c_MPEG: Container.c_MPEG,
     Container.c_WEBM: Container.c_MATROSKA_WEBM_DEMUXER,
 }
 assert set(_DEMUXER_MAP).issubset(set(Container))

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -75,6 +75,37 @@ class Container(enum.Enum):
     def list_supported_formats(vformat):
         return list_supported_formats()
 
+    def get_demuxer(self):
+        return _DEMUXER_MAP[self].value
+
+    def is_exclusive_demuxer(self):
+        return self in _EXCLUSIVE_DEMUXERS
+
+
+# This set containe demuxers that cannot be used as muxers in ffmpeg.
+_EXCLUSIVE_DEMUXERS = {
+    Container.c_QUICK_TIME_DEMUXER,
+    Container.c_MATROSKA_WEBM_DEMUXER,
+}
+
+
+# This dictionary defines which ffmpeg demuxer handles files encoded by which
+# muxer.
+_DEMUXER_MAP = {
+    Container.c_3G2: Container.c_QUICK_TIME_DEMUXER,
+    Container.c_3GP: Container.c_QUICK_TIME_DEMUXER,
+    Container.c_AVI: Container.c_AVI,
+    Container.c_F4V: Container.c_QUICK_TIME_DEMUXER,
+    Container.c_MATROSKA: Container.c_MATROSKA_WEBM_DEMUXER,
+    Container.c_MOV: Container.c_QUICK_TIME_DEMUXER,
+    Container.c_MP4: Container.c_QUICK_TIME_DEMUXER,
+    Container.c_MPEG: Container.c_MPEG,
+    Container.c_WEBM: Container.c_MATROSKA_WEBM_DEMUXER,
+}
+assert set(_DEMUXER_MAP).issubset(set(Container))
+assert set(_DEMUXER_MAP.values()).issubset(set(Container))
+assert set(_DEMUXER_MAP) & _EXCLUSIVE_DEMUXERS == set()
+
 
 _MOV_CODECS = {
     "videocodecs": [

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -14,8 +14,6 @@ class Container(enum.Enum):
     c_MKV = 'mkv'
     c_MPEG = 'mpeg'
     c_MOV = 'mov'
-    c_M4A = 'm4a'
-    c_MJ2 = 'mj2'
 
     # Sometimes ffmpeg can't tell us precise format, but returns
     # group of similar formats. We need to heve them listed
@@ -118,11 +116,9 @@ _MPEG_CODECS = {
 _CONTAINER_SUPPORTED_CODECS = {
     "mp4": _QUICKTIME_CODECS,
     "mov": _QUICKTIME_CODECS,
-    "m4a": _QUICKTIME_CODECS,
     "mkv": _QUICKTIME_CODECS,
     "3gp": _3GP_CODECS,
     "3g2": _3GP_CODECS,
-    "mj2": _QUICKTIME_CODECS,
     "mov,mp4,m4a,3gp,3g2,mj2": _QUICKTIME_CODECS,
     "avi": _AVI_CODECS,
     "mpeg": _MPEG_CODECS,

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -14,6 +14,7 @@ class Container(enum.Enum):
     c_MKV = 'mkv'
     c_MPEG = 'mpeg'
     c_MOV = 'mov'
+    c_WEBM = "webm"
 
     # Sometimes ffmpeg can't tell us precise format, but returns
     # group of similar formats. We need to heve them listed
@@ -108,8 +109,8 @@ _MKV_CODECS = {
 
 _WEBM_CODECS = {
     "videocodecs": [
-        "vp9",
         "vp8",
+        "vp9",
     ],
     "audiocodecs": [
         "opus",
@@ -171,6 +172,7 @@ _CONTAINER_SUPPORTED_CODECS = {
     "mov,mp4,m4a,3gp,3g2,mj2": _QUICKTIME_CODECS,
     "avi": _AVI_CODECS,
     "mpeg": _MPEG_CODECS,
+    "webm": _WEBM_CODECS,
 }
 
 _resolutions = {

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -65,10 +65,31 @@ class Container(enum.Enum):
         return list_supported_formats()
 
 
+_MOV_CODECS = {
+    "videocodecs": [
+        "h264",
+        "h265",
+        "HEVC",
+        "mpeg1video",
+        "mpeg2video",
 
-_QUICKTIME_CODECS = {
-    "videocodecs": ["h264", "h265", "HEVC", "mpeg1video", "mpeg2video"],
-    "audiocodecs": ["mp3", "aac"]
+    ],
+    "audiocodecs": [
+        "mp3",
+        "aac",
+    ]
+}
+
+_MP4_CODECS = {
+    "videocodecs": [
+        "h264",
+        "h265",
+        "HEVC",
+    ],
+    "audiocodecs": [
+        "aac",
+        "mp3",
+    ]
 }
 
 _MKV_CODECS = {
@@ -127,9 +148,23 @@ _MPEG_CODECS = {
     ]
 }
 
+_QUICKTIME_CODECS = {
+    "videocodecs": list(set(
+        _MOV_CODECS["videocodecs"] +
+        _MP4_CODECS["videocodecs"] +
+        _3GP_CODECS["videocodecs"]
+    )),
+    "audiocodecs": list(set(
+        _MOV_CODECS["audiocodecs"] +
+        _MP4_CODECS["audiocodecs"] +
+        _3GP_CODECS["audiocodecs"]
+    )),
+}
+
+
 _CONTAINER_SUPPORTED_CODECS = {
-    "mp4": _QUICKTIME_CODECS,
-    "mov": _QUICKTIME_CODECS,
+    "mp4": _MP4_CODECS,
+    "mov": _MOV_CODECS,
     "mkv": _MKV_CODECS,
     "3gp": _3GP_CODECS,
     "3g2": _3GP_CODECS,

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -19,8 +19,8 @@ class Container(enum.Enum):
     # Sometimes ffmpeg can't tell us precise format, but returns
     # group of similar formats. We need to heve them listed
     # to allow them in validation functions.
-    c_QUICK_TIME = "mov,mp4,m4a,3gp,3g2,mj2"
-    c_MATROSKA_WEBM = "matroska,webm"
+    c_QUICK_TIME_DEMUXER = "mov,mp4,m4a,3gp,3g2,mj2" # QuickTime / MOV
+    c_MATROSKA_WEBM_DEMUXER = "matroska,webm"        # Matroska / WebM
 
 
     # Normally enum throws ValueError, when initialization value is invalid.

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -71,6 +71,20 @@ _QUICKTIME_CODECS = {
     "audiocodecs": ["mp3", "aac"]
 }
 
+_MKV_CODECS = {
+    "videocodecs": [
+        "h264",
+        "h265",
+        "HEVC",
+        "mpeg1video",
+        "mpeg2video",
+    ],
+    "audiocodecs": [
+        "mp3",
+        "aac",
+    ]
+}
+
 _WEBM_CODECS = {
     "videocodecs": [
         "vp9",
@@ -116,7 +130,7 @@ _MPEG_CODECS = {
 _CONTAINER_SUPPORTED_CODECS = {
     "mp4": _QUICKTIME_CODECS,
     "mov": _QUICKTIME_CODECS,
-    "mkv": _QUICKTIME_CODECS,
+    "mkv": _MKV_CODECS,
     "3gp": _3GP_CODECS,
     "3g2": _3GP_CODECS,
     "mov,mp4,m4a,3gp,3g2,mj2": _QUICKTIME_CODECS,

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -112,13 +112,9 @@ def validate_format(video_format):
     return True
 
 
-def _get_format_names(metadata):
-    return meta.get_format(metadata).split(",")
-
-
 def validate_format_metadata(metadata):
     try:
-        if _get_format_names(metadata) == ['']:
+        if meta.get_format(metadata) in ['', None]:
             raise InvalidFormatMetadata(message="No format names")
     except KeyError:
         raise InvalidFormatMetadata("Invalid format metadata")

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -19,6 +19,11 @@ class UnsupportedVideoFormat(InvalidVideo):
         super().__init__(message="Unsupported video format: {}".format(video_format))
 
 
+class UnsupportedTargetVideoFormat(InvalidVideo):
+    def __init__(self, video_format):
+        super().__init__(message="Muxing not supported for video format: {}".format(video_format))
+
+
 class UnsupportedVideoCodec(InvalidVideo):
     def __init__(self, video_codec, video_format):
         super().__init__(message="Unsupported video codec: {} for video format: {}".format(video_codec, video_format))
@@ -58,7 +63,7 @@ class UnsupportedAudioCodecConversion(InvalidVideo):
 def validate_video(metadata):
     try:
         validate_format_metadata(metadata)
-        
+
         video_format = meta.get_format(metadata)
         validate_format(video_format)
         validate_video_stream_existence(metadata=metadata)
@@ -72,7 +77,7 @@ def validate_video(metadata):
 
 
 def validate_transcoding_params(src_params, dst_params):
-    
+
     # Validate format
     validate_format(src_params["format"])
     validate_format(dst_params["format"])
@@ -109,6 +114,14 @@ def _get_extension_from_filename(filename):
 def validate_format(video_format):
     if video_format not in formats.list_supported_formats():
         raise UnsupportedVideoFormat(video_format=video_format)
+    return True
+
+
+def validate_target_format(video_format):
+    validate_format(video_format)
+
+    if formats.Container(video_format).is_exclusive_demuxer():
+        raise UnsupportedTargetVideoFormat(video_format=video_format)
     return True
 
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,7 +1,61 @@
 import sys
 import pytest
+from unittest import TestCase
 
 import ffmpeg_tools as ffmpeg
+
+
+class TestContainer(TestCase):
+
+    def test_get_demuxer_should_return_demuxer_from_demuxer_map(self):
+        assert ffmpeg.formats.Container.c_WEBM in ffmpeg.formats._DEMUXER_MAP
+
+        self.assertEqual(
+            ffmpeg.formats.Container.c_WEBM.get_demuxer(),
+            ffmpeg.formats.Container.c_MATROSKA_WEBM_DEMUXER.value)
+
+    def test_get_demuxer_should_return_muxer_if_not_present_in_demuxer_map(self):
+        assert ffmpeg.formats.Container.c_AVI not in ffmpeg.formats._DEMUXER_MAP
+
+        self.assertEqual(
+            ffmpeg.formats.Container.c_AVI.get_demuxer(),
+            ffmpeg.formats.Container.c_AVI.value)
+
+    def test_get_demuxer_should_work_when_used_with_an_exclusive_demuxer(self):
+        assert ffmpeg.formats.Container.c_QUICK_TIME_DEMUXER in ffmpeg.formats._EXCLUSIVE_DEMUXERS
+
+        self.assertEqual(
+            ffmpeg.formats.Container.c_QUICK_TIME_DEMUXER.get_demuxer(),
+            ffmpeg.formats.Container.c_QUICK_TIME_DEMUXER.value)
+
+    def test_is_exclusive_demuxer_should_return_values_based_on_exclusive_demuxers_dict(self):
+        assert ffmpeg.formats.Container.c_QUICK_TIME_DEMUXER in ffmpeg.formats._EXCLUSIVE_DEMUXERS
+        assert ffmpeg.formats.Container.c_MOV not in ffmpeg.formats._EXCLUSIVE_DEMUXERS
+
+        self.assertTrue(ffmpeg.formats.Container.c_QUICK_TIME_DEMUXER.is_exclusive_demuxer())
+        self.assertFalse(ffmpeg.formats.Container.c_MOV.is_exclusive_demuxer())
+
+    def test_get_matching_muxers_should_return_all_matching_muxers(self):
+        assert ffmpeg.formats.Container.c_MATROSKA_WEBM_DEMUXER in ffmpeg.formats._DEMUXER_MAP.values()
+        assert ffmpeg.formats.Container.c_MATROSKA_WEBM_DEMUXER not in ffmpeg.formats._DEMUXER_MAP
+
+        self.assertEqual(
+            ffmpeg.formats.Container.c_MATROSKA_WEBM_DEMUXER.get_matching_muxers(),
+            {ffmpeg.formats.Container.c_MATROSKA, ffmpeg.formats.Container.c_WEBM})
+
+    def test_get_matching_muxers_should_return_muxer_itself_if_not_present_in_muxer_map(self):
+        assert ffmpeg.formats.Container.c_AVI not in ffmpeg.formats._DEMUXER_MAP
+
+        self.assertEqual(
+            ffmpeg.formats.Container.c_AVI.get_matching_muxers(),
+            {ffmpeg.formats.Container.c_AVI})
+
+    def test_get_matching_muxers_should_never_return_exclusive_demuxers(self):
+        assert ffmpeg.formats.Container.c_QUICK_TIME_DEMUXER in ffmpeg.formats._EXCLUSIVE_DEMUXERS
+
+        self.assertNotIn(
+            ffmpeg.formats.Container.c_QUICK_TIME_DEMUXER,
+            ffmpeg.formats.Container.c_QUICK_TIME_DEMUXER.get_matching_muxers())
 
 
 class TestSupportedFormats(object):
@@ -82,7 +136,7 @@ class TestResolutionsTools(object):
 
     def test_listing_bad_propotions(self):
         resolution_list = ffmpeg.formats.list_matching_resolutions( [2, 1] )
-        
+
         # Function returns at least resolution, that was passed in parameter.
         assert( len( resolution_list ) == 1 )
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,9 +4,11 @@ import sys
 from ffmpeg_tools.formats import list_supported_formats, list_supported_video_codecs, list_supported_audio_codecs
 from ffmpeg_tools.meta import get_metadata
 from ffmpeg_tools.validation import UnsupportedVideoCodec, UnsupportedVideoFormat, \
-    MissingVideoStream, UnsupportedAudioCodec, InvalidVideo, MissingVideoStream, InvalidFormatMetadata
+    UnsupportedTargetVideoFormat, MissingVideoStream, UnsupportedAudioCodec, \
+    InvalidVideo, MissingVideoStream, InvalidFormatMetadata
 
 import ffmpeg_tools.validation as validation
+import ffmpeg_tools.formats as formats
 import ffmpeg_tools.meta as meta
 
 
@@ -37,6 +39,19 @@ class TestInputValidation(TestCase):
     def test_validate_invalid_video_format(self):
         with self.assertRaises(UnsupportedVideoFormat):
             validation.validate_format("jpg")
+
+
+    def test_validate_target_format_should_accept_muxers(self):
+        assert not formats.Container.c_MP4.is_exclusive_demuxer()
+
+        self.assertTrue(validation.validate_target_format(formats.Container.c_MP4.value))
+
+
+    def test_validate_target_format_should_reject_exclusive_demuxers(self):
+        assert formats.Container.c_QUICK_TIME_DEMUXER.is_exclusive_demuxer()
+
+        with self.assertRaises(UnsupportedTargetVideoFormat):
+            validation.validate_target_format(formats.Container.c_QUICK_TIME_DEMUXER.value)
 
 
     def test_validate_valid_video_codecs(self):


### PR DESCRIPTION
This pull request changes the way the library is handling container formats. They now correspond to muxers and demuxers rather than file extensions. This is necessary to be able to use those container names with ffmpeg's `-f` option.

### Details
1) It's now possible to pass container type to ffmpeg commands. The parameter is optional - if not specified the the `-f` option is not used and ffmpeg determines the container type based on the output file extension as before.
2) The values in `Container` enum were corresponding to file extensions. Now they represent muxer and demuxer names that can be used with ffmpeg's `-f` option.
    - When we analyze a file with ffprobe we only get the demuxer name. There are often multiple muxers handled by a single demuxer. An additional dict called `_DEMUXER_MAP` allows us to find those muxers. This is useful in several ways:
        - We don't have to explicitly define codecs supported by a demuxer. Those are simply codecs supported by any of the corresponding muxers.
        - In tests when we use a muxer we know which demuxer to expect in ffprobe output.
        - Might also be useful in validations.
3) New containers, codecs and demuxers:
    - WebM container: the code already had codec list for that format but it was not used.
    - `opus` was not defined in `AudioCodec` even though it was used in the supported codec list of WebM.
    - `matroska,webm` demuxer added to `Container`.
    - Removed `m4a` and `mj2` containers. `m4a` is just `mp4` and it's handled by the same muxer. I'm not sure about `mj2` but I can't see a dedicated muxer for it in `ffmpeg -muxers`.
4) Matroska, MP4 and MOV now have separate supported codec lists. They are handled by the same demuxer (actually Matroska is not - i think it was an error) but they still support different codecs so the lists are going to diverge. For example I don't think MP4 really supports `mpeg1video` and `mpeg2video` (I removed them).
5) Broad exception handlers that catch anything replaced with normal `if`s. Such handlers make it really hard to for me to debug this stuff. They often silence syntax and type errors.

### Dependencies
This pull request depends on #4 and should not be merged before it. I've actually put the branch on top of #5 because it's going to be merged together with #4 anyway.

**NOTE**: I have set the base branch of this pull request to `remove-m3u-playlist-support-leftovers` (#5). Please remember to change the base branch back to master before you merge.