### PR TITLE
Intermediate container independent of file extension

### DIFF
--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -125,26 +125,29 @@ def extract_streams_command(input_file,
     return cmd
 
 
-def split_video(input_file, output_dir, split_len):
+def split_video(input_file, output_dir, split_len, container=None):
     [_, filename] = os.path.split(input_file)
     [basename, _] = os.path.splitext(filename)
 
     output_list_file = os.path.join(output_dir, basename + "-segment-list.txt")
 
-    split_list_file = split(input_file, output_list_file, split_len)
+    split_list_file = split(input_file, output_list_file, split_len, container)
 
     return split_list_file
 
 
-def split(input_file, output_list_file, segment_time):
+def split(input_file, output_list_file, segment_time, container=None):
     cmd, file_list = split_video_command(input_file, output_list_file,
-                                         segment_time)
+                                         segment_time, container)
     exec_cmd(cmd)
 
     return file_list
 
 
-def split_video_command(input_file, output_list_file, segment_time):
+def split_video_command(input_file,
+                        output_list_file,
+                        segment_time,
+                        container=None):
     (_, input_filename) = os.path.split(input_file)
     (input_basename, input_extension) = os.path.splitext(input_filename)
 
@@ -156,6 +159,9 @@ def split_video_command(input_file, output_list_file, segment_time):
         "-i", input_file,
         "-codec", "copy",
         "-f", "segment",
+    ] + ([
+        "-segment_format", container,
+    ] if container is not None else []) + [
         "-reset_timestamps", "1",
         "-segment_time", f"{segment_time}",
         "-segment_list_type", "flat",

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -149,9 +149,17 @@ def split_video_command(input_file,
                         segment_time,
                         container=None):
     (_, input_filename) = os.path.split(input_file)
-    (input_basename, input_extension) = os.path.splitext(input_filename)
+    (input_basename, extension) = os.path.splitext(input_filename)
 
     (output_dir, _) = os.path.split(output_list_file)
+    if container is not None:
+        # ffmpeg with -segment_format option fails if the output file name
+        # pattern has no extension in it or has an extension not supported by
+        # ffmpeg. This seems to be a bug, even reported in
+        # (https://trac.ffmpeg.org/ticket/4483) but closed as invalid (why?).
+        # A simple workaround is to add any valid extension to the pattern.
+        # The -segment_format option has priority over the file extension.
+        extension += '.mkv'
 
     cmd = [
         FFMPEG_COMMAND,
@@ -166,7 +174,7 @@ def split_video_command(input_file,
         "-segment_time", f"{segment_time}",
         "-segment_list_type", "flat",
         "-segment_list", output_list_file,
-        f"{output_dir}/{input_basename}_%d{input_extension}",
+        f"{output_dir}/{input_basename}_%d{extension}",
     ]
 
     return cmd, output_list_file

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -57,6 +57,26 @@ class TestContainer(TestCase):
             ffmpeg.formats.Container.c_QUICK_TIME_DEMUXER,
             ffmpeg.formats.Container.c_QUICK_TIME_DEMUXER.get_matching_muxers())
 
+    def test_get_intermediate_muxer_should_return_values_from_safe_intermediate_formats_dict(self):
+        demuxer = ffmpeg.formats.Container.c_MATROSKA_WEBM_DEMUXER
+        assert demuxer in ffmpeg.formats._SAFE_INTERMEDIATE_FORMATS
+
+        expected_intermediate_muxer = ffmpeg.formats._SAFE_INTERMEDIATE_FORMATS[demuxer]
+
+        self.assertEqual(
+            demuxer.get_intermediate_muxer(),
+            expected_intermediate_muxer.value)
+
+    def test_get_intermediate_muxer_should_return_self_if_demuxer_not_present_in_safe_intermediate_formats_dict(self):
+        demuxer = ffmpeg.formats.Container.c_AVI
+        assert demuxer not in ffmpeg.formats._SAFE_INTERMEDIATE_FORMATS
+
+        expected_intermediate_muxer = demuxer
+
+        self.assertEqual(
+            demuxer.get_intermediate_muxer(),
+            expected_intermediate_muxer.value)
+
 
 class TestSupportedFormats(object):
 
@@ -140,3 +160,12 @@ class TestResolutionsTools(object):
         # Function returns at least resolution, that was passed in parameter.
         assert( len( resolution_list ) == 1 )
 
+
+
+class TestHelperFunctions(TestCase):
+
+    def test_get_safe_intermediate_format_for_demuxer(self):
+        demuxer = ffmpeg.formats.Container.c_AVI
+        self.assertEqual(
+            ffmpeg.formats.get_safe_intermediate_format_for_demuxer(demuxer),
+            demuxer.get_intermediate_muxer())


### PR DESCRIPTION
This pull request adds support for specifying container (muxer) type for file segments produced by the split command. It also adds helper methods and definitions to `Container` for selecting a muxer that works for all files supported by a specific demuxer.

### Details
1) Currently `mp4` is defined as the intermediate format for `c_QUICK_TIME_DEMUXER` and `matroska` for `MATROSKA_WEBM_DEMUXER`. All other currently supported demuxers map to themselves. This is as close as possible to what ffmpeg was selecting before based on the file extension (as long as the extension was present and correct) but not exactly the same - e.g. the only hint as to what's really in a file handled by the `mov,mp4,m4a,3gp,3g2,mj2` demuxer is the extension and now such files always are remuxed into `mp4`.
2) The effect of this particular choice of intermediate formats has not been tested on the full test video set yet and may need to be tweaked later - in the pull request that adds that set to Golem.
3) `-segment_format` used for passing muxer to ffmpeg seems to have a bug and works only if the file has an extension (see https://github.com/golemfactory/golem/pull/4255#issuecomment-500452935). We had to add a big, ugly workaround for that (adding a fake extension and removing it later).

### Dependencies
This pull request depends on #6 and should not be merged before it. The branch is on top of it.

**NOTE**: I have set the base branch of this pull request to `muxers-and-demuxers` (#6). Please remember to change the base branch back to master before you merge.