### PR TITLE
640x260 is not a 16:9 resolution

### DIFF
--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -331,7 +331,7 @@ assert set(_CONTAINER_SUPPORTED_CODECS) & {d.value for d in _EXCLUSIVE_DEMUXERS}
 
 _resolutions = {
     "16:9": [
-        [640, 260],
+        [640, 360],
         [1280, 720],
         [1536, 864],
         [1920, 1080],

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -254,7 +254,7 @@ class TestConversionValidation(TestCase):
 
     def test_resolution_change(self):
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
-        dst_params = self.create_params("mp4", [640, 260], "h264", "mp3" )
+        dst_params = self.create_params("mp4", [640, 360], "h264", "mp3" )
 
         self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
 
@@ -262,7 +262,7 @@ class TestConversionValidation(TestCase):
     def test_no_audio_codec(self):
         # It is valid to not provide audio codec.
         src_params = self.create_params("mp4", [1920, 1080], "h264", None )
-        dst_params = self.create_params("mp4", [640, 260], "h264", None )
+        dst_params = self.create_params("mp4", [640, 360], "h264", None )
 
         self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
 


### PR DESCRIPTION
It looks like a typo. I think it should have been 640x360.

I'd normally add a test that exposes the bug but it's hard to do so with a static definition. I use a different strategy to validate definitions and avoid simple mistakes like this in my code. I always add some assertions immediately after my definitions. For example, in this case I'd do it like this:

``` python
_resolutions = {
    "16:9": [
        [1280, 720],
        [1536, 864],
    ...
}
assert all(":" in aspect_ratio                                       for aspect_ratio, resolutions in _resolutions for resolution in resolutions)
assert all(len(resolution) == 2                                      for aspect_ratio, resolutions in _resolutions for resolution in resolutions)
assert all(aspect_ratio_matches_resolution(resolution, aspect_ratio) for aspect_ratio, resolutions in _resolutions for resolution in resolutions)
assert is_unique([resolution                                         for aspect_ratio, resolutions in _resolutions for resolution in resolutions]))
```

This may look weird to some because instead of using code at runtime to check these definitions you could just check them once and make sure they're correct, right? But in practice it works better because code is not written once and immutable - it's getting modified all the time. This approach lets you catch simple errors like this one and also expresses your assumptions in a way that lets Python enforce them on anyone modifying these definitions in the future. E.g. in the example above anyone adding a new entry will see that the aspect ratio must be a string with a ":", that resolutions are two-element lists and that these values divided by one another should give us the aspect ratio.

`aspect_ratio_matches_resolution()` would be a utility function defined elsewhere. It should deal with splitting the aspect ratio string into two ints and with the fact that the aspect ratio is not exact (e.g. that both 1366x768 and 1360x768 are acceptable approximation of 16:9 aspect ratio). Having to write this function add some programming overhead  but this is rare in my experience. Most definitions can be validated with one-liners that don't require extra definitions.

### Dependencies
**NOTE**: I have set the base branch of this pull request to `review-fixes-all-files-codecs-framerates-resolutions` (#13). Please remember to change the base branch back to master before you merge.