### PR TITLE
[P2] Allow transcoding to any resolution with the same aspect ratio

### DIFF
--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -330,39 +330,6 @@ _CONTAINER_SUPPORTED_CODECS = {
 assert set(_CONTAINER_SUPPORTED_CODECS) & {d.value for d in _EXCLUSIVE_DEMUXERS} == set(), \
     "Supported codecs for exclusive demuxers can be determined automatically; no need to define them here"
 
-_resolutions = {
-    "16:9": [
-        [640, 360],
-        [1280, 720],
-        [1536, 864],
-        [1920, 1080],
-        [2048, 1152],
-        [2560, 1440],
-        [3840, 2160],
-        [1366, 768],
-        [1360, 768]
-    ],
-    "4:3": [
-        [320, 240],
-        [640, 480],
-        [800, 600],
-        [1024, 768]
-    ],
-    "16:10": [
-        [1280, 800],
-        [1440, 900],
-        [1680, 1050],
-        [1920, 1200]
-    ],
-    "5:4": [
-        [1280, 1024]
-    ],
-    "21:9": [
-        [2560, 1080],
-        [3440, 1440]
-    ]
-}
-
 _aspect_ratio_overrides = {
     "16:9": [
         [1366, 768],
@@ -448,13 +415,6 @@ def _list_supported_audio_codecs_for_exclusive_demuxer(demuxer: Container):
         for muxer in demuxer.get_matching_muxers()
         for codec in muxer.get_supported_audio_codecs()
     ))
-
-
-def list_matching_resolutions(resolution):
-    for aspect, resolutions_list in _resolutions.items():
-        if resolution in resolutions_list:
-            return resolutions_list
-    return [resolution]
 
 
 def get_effective_aspect_ratio(resolution: list) -> str:

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -1,4 +1,5 @@
 import enum
+from math import gcd
 
 from . import validation
 from . import codecs
@@ -362,6 +363,17 @@ _resolutions = {
     ]
 }
 
+_aspect_ratio_overrides = {
+    "16:9": [
+        [1366, 768],
+        [1360, 768]
+    ],
+    "21:9": [
+        [2560, 1080],
+        [3440, 1440]
+    ]
+}
+
 _frame_rates = {
     # NOTE 1: The same frame rate can often be represented a few slightly
     # different ways. For example 24 FPS could be 24, '24', '24/1', '48/2'
@@ -443,6 +455,19 @@ def list_matching_resolutions(resolution):
         if resolution in resolutions_list:
             return resolutions_list
     return [resolution]
+
+
+def get_effective_aspect_ratio(resolution: list) -> str:
+    for aspect, resolutions_list in _aspect_ratio_overrides.items():
+        if resolution in resolutions_list:
+            return aspect
+    return calculate_aspect_ratio(resolution)
+
+
+def calculate_aspect_ratio(resolution: list) -> str:
+    assert len(resolution) == 2
+    resolution_gcd = gcd(resolution[0], resolution[1])
+    return f"{resolution[0] // resolution_gcd}:{resolution[1] // resolution_gcd}"
 
 
 def list_supported_frame_rates():

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -192,9 +192,14 @@ def validate_audio_codec(video_format, audio_codec):
 
 
 def validate_resolution(src_resolution, target_resolution):
-    if not target_resolution in formats.list_matching_resolutions(src_resolution):
-        raise InvalidResolution(src_resolution, target_resolution)
-    return True
+    """
+    Validate if aspect ratio of source resolution and
+    target resolution are the same.
+    """
+    if formats.get_effective_aspect_ratio(src_resolution) == \
+            formats.get_effective_aspect_ratio(target_resolution):
+        return True
+    raise InvalidResolution(src_resolution, target_resolution)
 
 
 def validate_frame_rate(src_frame_rate, target_frame_rate):

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
 import setuptools
 
+
+tests_require = [
+    'pytest'
+]
+
 setuptools.setup(
     name='ffmpeg-tools',
     version='0.14.1',
@@ -9,6 +14,6 @@ setuptools.setup(
     maintainer_email='tech@golem.network',
     packages=setuptools.find_packages(exclude=["tests/"]),
     python_requires='>=3.5',
-    zip_safe=False
+    zip_safe=False,
+    tests_require=tests_require,
 )
-

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ import setuptools
 
 
 tests_require = [
-    'pytest'
+    'pytest',
+    'parameterized',
 ]
 
 setuptools.setup(

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -144,24 +144,6 @@ class TestSupportedAudioCodecs(object):
         assert not container.is_supported_audio_codec("bla")
 
 
-class TestResolutionsTools(object):
-
-    def test_listing(self):
-        resolution_list = ffmpeg.formats.list_matching_resolutions( [1920, 1080] )
-        assert( len( resolution_list ) > 2 )
-
-    def test_listing2(self):
-        resolution_list = ffmpeg.formats.list_matching_resolutions( [1280, 720] )
-        assert( len( resolution_list ) > 2 )
-
-    def test_listing_bad_propotions(self):
-        resolution_list = ffmpeg.formats.list_matching_resolutions( [2, 1] )
-
-        # Function returns at least resolution, that was passed in parameter.
-        assert( len( resolution_list ) == 1 )
-
-
-
 class TestHelperFunctions(TestCase):
 
     def test_get_safe_intermediate_format_for_demuxer(self):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -3,6 +3,7 @@ import pytest
 from unittest import TestCase
 
 import ffmpeg_tools as ffmpeg
+from parameterized import parameterized
 
 
 class TestContainer(TestCase):
@@ -142,6 +143,36 @@ class TestSupportedAudioCodecs(object):
         assert container.is_supported_audio_codec(acodec)
         assert container.is_supported_audio_codec(acodec_class)
         assert not container.is_supported_audio_codec("bla")
+
+
+class TestAspectRatioCalculations(TestCase):
+
+    @parameterized.expand([
+        ([333, 333], "1:1"),
+        ([333, 666], "1:2"),
+        ([1366, 768], "16:9"),
+        ([1360, 768], "16:9"),
+        ([1920, 1080], "16:9"),
+        ([2560, 1080], "21:9"),
+        ([3440, 1440], "21:9"),
+    ])
+    def test_effective_aspect_ratio(self, resolution, expected_aspect_ratio):
+        aspect_ratio = ffmpeg.formats.get_effective_aspect_ratio(resolution)
+        self.assertEqual(aspect_ratio, expected_aspect_ratio)
+
+    @parameterized.expand([
+        ([333, 666], "1:2"),
+        ([1024, 768], "4:3"),
+        ([1920, 1080], "16:9"),
+        ([1280, 1024], "5:4"),
+        ([1360, 768], "85:48"),
+        ([1366, 768], "683:384"),
+        ([2560, 1080], "64:27"),
+        ([3440, 1440], "43:18"),
+    ])
+    def test_calculate_aspect_ratio(self, resolution, expected_aspect_ratio):
+        aspect_ratio = ffmpeg.formats.calculate_aspect_ratio(resolution)
+        self.assertEqual(aspect_ratio, expected_aspect_ratio)
 
 
 class TestHelperFunctions(TestCase):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -293,6 +293,9 @@ class TestConversionValidation(TestCase):
 
     @parameterized.expand([
         ([333, 333], [333, 333]),
+        ([333, 666], [666, 1332]),
+        ([1920, 1080], [1366, 768]),
+        ([3840, 2160], [2560, 1440]),
     ])
     def test_nonstandard_resolution_change(
             self,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,6 +10,7 @@ from ffmpeg_tools.validation import UnsupportedVideoCodec, UnsupportedVideoForma
 import ffmpeg_tools.validation as validation
 import ffmpeg_tools.formats as formats
 import ffmpeg_tools.meta as meta
+from parameterized import parameterized
 
 
 class TestInputValidation(TestCase):
@@ -290,11 +291,17 @@ class TestConversionValidation(TestCase):
         with self.assertRaises(validation.InvalidResolution):
             validation.validate_transcoding_params(src_params, dst_params)
 
-
-    def test_nonstandard_resolution_change(self):
+    @parameterized.expand([
+        ([333, 333], [333, 333]),
+    ])
+    def test_nonstandard_resolution_change(
+            self,
+            src_resolution,
+            target_resolution,
+    ):
         # It is allowed to convert video with non standard resolution
         # to the same resolution.
-        src_params = self.create_params("mp4", [333, 333], "h264", "mp3" )
-        dst_params = self.create_params("mp4", [333, 333], "h264", "mp3" )
+        src_params = self.create_params("mp4", src_resolution, "h264", "mp3")
+        dst_params = self.create_params("mp4", target_resolution, "h264", "mp3")
 
         self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))


### PR DESCRIPTION
This pull request adjusts validations to allow transcoding to any resolution that has the same aspect ratio as the original resolution.

### Things of note
1) The original `_resolutions` dict had some resolutions with actual aspect ratio slightly different than than the stated one. For example 1366x768 is really 683:384 and 1360x768 is 85:48 but the original list had them both as 16:9. Similarly 2560x1080 and 3440x1440 are not exactly 21:9. We handle this by defining exceptions in `_aspect_ratio_overrides`.
2) We added `parameterized` as a dependency to be able to create parameterized tests.
3) There was no mechanism for defining test dependencies in the project. We used `tests_require` in `setup.py` for that purpose.

### Dependencies
This pull request depends on #14 and should not be merged before it.

**NOTE**: I have set the base branch of this pull request to `fix-640x260-is-not-a-16-9-resolution` (#14). Please remember to change the base branch back to master before you merge.