### PR TITLE
[P6a] Audio channel layout validations

### DIFF
--- a/ffmpeg_tools/codecs.py
+++ b/ffmpeg_tools/codecs.py
@@ -135,8 +135,17 @@ _VIDEO_SUPPORTED_CONVERSIONS = {
 }
 
 _AUDIO_SUPPORTED_CONVERSIONS = {
-    "aac": [ "aac" ],
-    "mp3": [ "mp3" ],
+    #          "aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8", "wmapro", "wmav2", "vorbis"
+    "aac":    ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "ac3":    ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "amr_nb": ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "mp2":    ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "mp3":    ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "opus":   ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "pcm_u8": ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "wmapro": ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "wmav2":  ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "vorbis": ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
 }
 
 

--- a/ffmpeg_tools/meta.py
+++ b/ffmpeg_tools/meta.py
@@ -48,6 +48,13 @@ def get_format(metadata):
     return metadata["format"]["format_name"]
 
 
+def get_audio_stream(metadata):
+    for stream in metadata['streams']:
+        if stream["codec_type"] == "audio":
+            return stream
+    return None
+
+
 def create_params(vformat, resolution, vcodec, acodec=None,
                   frame_rate=None, video_bitrate=None,
                   audio_bitrate=None, scaling_algorithm=None):

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -5,7 +5,7 @@ from . import formats
 from . import codecs
 
 
-
+_MAX_SUPPORTED_AUDIO_CHANNELS = 2
 
 
 class InvalidVideo(Exception):
@@ -64,6 +64,14 @@ class UnsupportedAudioCodecConversion(InvalidVideo):
         super().__init__(message="Unsupported audio codec conversion from {} to {}".format(src_codec, dst_codec))
 
 
+class UnsupportedAudioChannelLayout(InvalidVideo):
+    def __init__(self, audio_channels):
+        super().__init__(
+            message="Unsupported audio channel layout conversion. "
+                    "Unable to reliably preserve the {}-channel audio found "
+                    "in the input file in combination with other target parameters.".format(audio_channels)
+        )
+
 
 def validate_video(metadata):
     try:
@@ -98,7 +106,11 @@ def validate_transcoding_params(src_params, dst_params, src_metadata):
     try:
         validate_audio_codec(src_params["format"], src_params["audio"]["codec"])
         validate_audio_codec(dst_params["format"], dst_params["audio"]["codec"])
-        validate_audio_codec_conversion(src_params["audio"]["codec"], dst_params["audio"]["codec"])
+        validate_audio_codec_conversion(
+            src_params["audio"]["codec"],
+            dst_params["audio"]["codec"],
+            meta.get_audio_stream(src_metadata)
+        )
     except KeyError as _:
         # We accept only KeyError, because it means, there were now value
         # in dictionary. Note that validate functions can still throw other
@@ -222,8 +234,15 @@ def validate_video_codec_conversion(src_codec, dst_codec):
     return True
 
 
-def validate_audio_codec_conversion(src_codec, dst_codec):
+def validate_audio_codec_conversion(src_codec, dst_codec, audio_stream):
     codec = codecs.AudioCodec(src_codec)
     if dst_codec not in codec.get_supported_conversions():
         raise UnsupportedAudioCodecConversion(src_codec, dst_codec)
+    if src_codec != dst_codec and \
+            audio_stream['channels'] > _MAX_SUPPORTED_AUDIO_CHANNELS:
+        # Multi-channel audio is not supported by all audio codecs.
+        # We want to avoid creating another list to keep this information,
+        # so we’ll just assume that if we found multi-channel audio in the input,
+        # it’s OK and otherwise it’s not supported.
+        raise UnsupportedAudioChannelLayout(audio_stream['channels'])
     return True

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -81,7 +81,7 @@ def validate_video(metadata):
     return True
 
 
-def validate_transcoding_params(src_params, dst_params):
+def validate_transcoding_params(src_params, dst_params, src_metadata):
 
     # Validate format
     validate_format(src_params["format"])

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -217,13 +217,13 @@ def validate_frame_rate(src_frame_rate, target_frame_rate):
 
 def validate_video_codec_conversion(src_codec, dst_codec):
     codec = codecs.VideoCodec(src_codec)
-    if not dst_codec in codec.get_supported_conversions():
+    if dst_codec not in codec.get_supported_conversions():
         raise UnsupportedVideoCodecConversion(src_codec, dst_codec)
     return True
 
 
 def validate_audio_codec_conversion(src_codec, dst_codec):
     codec = codecs.AudioCodec(src_codec)
-    if not dst_codec in codec.get_supported_conversions():
+    if dst_codec not in codec.get_supported_conversions():
         raise UnsupportedAudioCodecConversion(src_codec, dst_codec)
     return True

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -89,7 +89,14 @@ def validate_video(metadata):
     return True
 
 
-def validate_transcoding_params(src_params, dst_params, src_metadata):
+def validate_transcoding_params(dst_params, src_metadata):
+
+    src_params = meta.create_params(
+        meta.get_format(src_metadata),
+        meta.get_resolution(src_metadata),
+        meta.get_video_codec(src_metadata),
+        meta.get_audio_codec(src_metadata),
+        meta.get_frame_rate(src_metadata))
 
     # Validate format
     validate_format(src_params["format"])

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -117,6 +117,9 @@ class TestMetadata(object):
     def test_get_format(self):
         assert(ffmpeg.meta.get_format(example_metadata) == "matroska,webm" )
 
+    def test_get_audio_stream(self):
+        assert (ffmpeg.meta.get_audio_stream(example_metadata) == example_metadata['streams'][1])
+
     def test_get_metadata_invalid_path(self):
         assert(ffmpeg.meta.get_metadata("blabla") == {})
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -226,6 +226,13 @@ class TestInputValidation(TestCase):
 
 class TestConversionValidation(TestCase):
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._metadata = get_metadata("tests/resources/ForBiggerBlazes-[codec=h264].mp4")
+
+    def setUp(self) -> None:
+        pass
+
     @staticmethod
     def create_params(container, resolution, vcodec, acodec=None):
         return meta.create_params(container, resolution, vcodec, acodec=acodec)
@@ -235,29 +242,28 @@ class TestConversionValidation(TestCase):
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mov", [1920, 1080], "h264", "mp3" )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
 
 
     def test_video_codec_change(self):
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [1920, 1080], "h265", "mp3" )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
 
 
     def test_invalid_audio_codec_change(self):
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "aac" )
-
         with self.assertRaises(validation.UnsupportedAudioCodecConversion):
-            validation.validate_transcoding_params(src_params, dst_params)
+            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
 
 
     def test_resolution_change(self):
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [640, 360], "h264", "mp3" )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
 
 
     def test_no_audio_codec(self):
@@ -265,7 +271,7 @@ class TestConversionValidation(TestCase):
         src_params = self.create_params("mp4", [1920, 1080], "h264", None )
         dst_params = self.create_params("mp4", [640, 360], "h264", None )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
 
 
     def test_invalid_src_video_codec(self):
@@ -273,7 +279,7 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
 
         with self.assertRaises(validation.UnsupportedVideoCodec):
-            validation.validate_transcoding_params(src_params, dst_params)
+            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
 
 
     def test_invalid_dst_video_codec(self):
@@ -281,7 +287,7 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [1920, 1080], "avi", "mp3" )
 
         with self.assertRaises(validation.UnsupportedVideoCodec):
-            validation.validate_transcoding_params(src_params, dst_params)
+            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
 
 
     def test_invalid_resolution_change(self):
@@ -289,7 +295,7 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [1280, 1024], "h264", "mp3" )
 
         with self.assertRaises(validation.InvalidResolution):
-            validation.validate_transcoding_params(src_params, dst_params)
+            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
 
     @parameterized.expand([
         ([333, 333], [333, 333]),
@@ -307,4 +313,5 @@ class TestConversionValidation(TestCase):
         src_params = self.create_params("mp4", src_resolution, "h264", "mp3")
         dst_params = self.create_params("mp4", target_resolution, "h264", "mp3")
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -239,66 +239,78 @@ class TestConversionValidation(TestCase):
     def create_params(container, resolution, vcodec, acodec=None):
         return meta.create_params(container, resolution, vcodec, acodec=acodec)
 
+    def modify_metadata_with_passed_values(self, container, resolution, vcodec, acodec=None):
+        metadata = copy.copy(self._metadata)
+        metadata['format']['format_name'] = container
+        metadata['streams'][0]['width'] = resolution[0]
+        metadata['streams'][0]['coded_width'] = resolution[0]
+        metadata['streams'][0]['height'] = resolution[1]
+        metadata['streams'][0]['coded_height'] = resolution[1]
+        metadata['streams'][0]['codec_name'] = vcodec
+        if acodec is not None:
+            metadata['streams'][1]['codec_name'] = acodec
+        return metadata
+
 
     def test_container_change(self):
-        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
+        metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mov", [1920, 1080], "h264", "mp3" )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata))
 
 
     def test_video_codec_change(self):
-        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
+        metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [1920, 1080], "h265", "mp3" )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata))
 
 
     def test_invalid_audio_codec_change(self):
         assert codecs.AudioCodec.WMAPRO.value not in codecs.AudioCodec.MP3.get_supported_conversions()
-        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
+        metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "wmapro" )
         with self.assertRaises(validation.UnsupportedAudioCodec):
-            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
+            validation.validate_transcoding_params(dst_params, metadata)
 
 
     def test_resolution_change(self):
-        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
+        metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [640, 360], "h264", "mp3" )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata))
 
 
     def test_no_audio_codec(self):
         # It is valid to not provide audio codec.
-        src_params = self.create_params("mp4", [1920, 1080], "h264", None )
+        metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", None )
         dst_params = self.create_params("mp4", [640, 360], "h264", None )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata))
 
 
     def test_invalid_src_video_codec(self):
-        src_params = self.create_params("mp4", [1920, 1080], "avi", "mp3" )
+        metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "avi", "mp3" )
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
 
         with self.assertRaises(validation.UnsupportedVideoCodec):
-            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
+            validation.validate_transcoding_params(dst_params, metadata)
 
 
     def test_invalid_dst_video_codec(self):
-        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
+        metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [1920, 1080], "avi", "mp3" )
 
         with self.assertRaises(validation.UnsupportedVideoCodec):
-            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
+            validation.validate_transcoding_params(dst_params, metadata)
 
 
     def test_invalid_resolution_change(self):
-        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
+        metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [1280, 1024], "h264", "mp3" )
 
         with self.assertRaises(validation.InvalidResolution):
-            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
+            validation.validate_transcoding_params(dst_params, metadata)
 
     @parameterized.expand([
         ([333, 333], [333, 333]),
@@ -313,23 +325,21 @@ class TestConversionValidation(TestCase):
     ):
         # It is allowed to convert video with non standard resolution
         # to the same resolution.
-        src_params = self.create_params("mp4", src_resolution, "h264", "mp3")
+        metadata = self.modify_metadata_with_passed_values("mp4", src_resolution, "h264", "mp3")
         dst_params = self.create_params("mp4", target_resolution, "h264", "mp3")
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata))
 
     def test_validate_audio_conversion_with_more_than_two_audio_channels(self):
-        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3")
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "aac")
         unsupported_metadata = copy.deepcopy(self._metadata)
         unsupported_metadata['streams'][1]['channels'] = validation._MAX_SUPPORTED_AUDIO_CHANNELS + 1
         with self.assertRaises(validation.UnsupportedAudioChannelLayout):
-            validation.validate_transcoding_params(src_params, dst_params, unsupported_metadata)
+            validation.validate_transcoding_params(dst_params, unsupported_metadata)
 
     def test_validate_conversion_without_audio_that_have_more_than_two_audio_channels(self):
-        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3")
         dst_params = self.create_params("mp4", [1920, 1080], "h265", "mp3")
         unsupported_metadata = copy.deepcopy(self._metadata)
         unsupported_metadata['streams'][1]['channels'] = validation._MAX_SUPPORTED_AUDIO_CHANNELS + 1
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, unsupported_metadata))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, unsupported_metadata))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -8,6 +8,7 @@ from ffmpeg_tools.validation import UnsupportedVideoCodec, UnsupportedVideoForma
     UnsupportedTargetVideoFormat, MissingVideoStream, UnsupportedAudioCodec, \
     InvalidVideo, MissingVideoStream, InvalidFormatMetadata
 
+import ffmpeg_tools.codecs as codecs
 import ffmpeg_tools.validation as validation
 import ffmpeg_tools.formats as formats
 import ffmpeg_tools.meta as meta
@@ -254,9 +255,10 @@ class TestConversionValidation(TestCase):
 
 
     def test_invalid_audio_codec_change(self):
+        assert codecs.AudioCodec.WMAPRO.value not in codecs.AudioCodec.MP3.get_supported_conversions()
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
-        dst_params = self.create_params("mp4", [1920, 1080], "h264", "aac" )
-        with self.assertRaises(validation.UnsupportedAudioCodecConversion):
+        dst_params = self.create_params("mp4", [1920, 1080], "h264", "wmapro" )
+        with self.assertRaises(validation.UnsupportedAudioCodec):
             validation.validate_transcoding_params(src_params, dst_params, self._metadata)
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,4 @@
+import copy
 from unittest import TestCase
 import sys
 
@@ -315,3 +316,18 @@ class TestConversionValidation(TestCase):
 
         self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
 
+    def test_validate_audio_conversion_with_more_than_two_audio_channels(self):
+        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3")
+        dst_params = self.create_params("mp4", [1920, 1080], "h264", "aac")
+        unsupported_metadata = copy.deepcopy(self._metadata)
+        unsupported_metadata['streams'][1]['channels'] = validation._MAX_SUPPORTED_AUDIO_CHANNELS + 1
+        with self.assertRaises(validation.UnsupportedAudioChannelLayout):
+            validation.validate_transcoding_params(src_params, dst_params, unsupported_metadata)
+
+    def test_validate_conversion_without_audio_that_have_more_than_two_audio_channels(self):
+        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3")
+        dst_params = self.create_params("mp4", [1920, 1080], "h265", "mp3")
+        unsupported_metadata = copy.deepcopy(self._metadata)
+        unsupported_metadata['streams'][1]['channels'] = validation._MAX_SUPPORTED_AUDIO_CHANNELS + 1
+
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, unsupported_metadata))


### PR DESCRIPTION
This pull request adds a validation that rejects videos with multi-channel audio unless the audio codec is not being changed.

### Things of note
1) The only allowed audio conversions until now were `mp3` -> `mp3` and `aac` -> `aac`. The reason that most of our test files were not failing this very strict validation is that audio codec change is validated only if it's explicitly specified. In this pull request we can no longer rely on that because we need a test that involves transcoding between different audio codecs.

    For that reason this pull request includes a commit that marks almost all conversions as allowed (the only forbidden conversion is `wmapro` because ffmpeg does not even have an encoder for it). I am not 100% sure that all these conversions work (I have not tested them all) but in my tests I have not seen anything that would indicate that they don't. My proposal is to enable them all and disable those that turn out to be broken on a case-by-case basis. We could also check which ones work but that would be a separate task. If you prefer a different set of allowed audio conversions, please let me know in a comment.

    The alternative would be to enable just one extra conversion (e.g. `mp3` -> `aac`) but this way we'd run into this problem again soon. We need a more complete set of allowed conversions.

2) Validations are performed only for the first audio stream in the video. This is how validations here always worked and I think it should be changed so that all audio streams are validated but for now we just plugged the new validations into the existing system.

### Dependencies
This pull request depends on #11 and should not be merged before it.

**NOTE**: I have set the base branch of this pull request to `allow-transcoding-to-any-resolution-with-same-aspect-ratio` (#11). Please remember to change the base branch back to `master` before you merge.