### PR TITLE
Review fixes for "Add codecs framerates resolutions"

### DIFF
--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -85,7 +85,7 @@ def validate_transcoding_params(src_params, dst_params):
 
     # Validate format
     validate_format(src_params["format"])
-    validate_format(dst_params["format"])
+    validate_target_format(dst_params["format"])
 
     # Validate video codec
     validate_video_codec(src_params["format"], src_params["video"]["codec"])


### PR DESCRIPTION
Fix for a small bug introduced in #9. `validate_target_format()` was defined but not actually used. 

This fix is required for `--runslow` tests added recently to https://github.com/golemfactory/golem/pull/4515 to pass. Without it the validations do not reject exclusive demuxers when someone attempts to use one as the target container.