### PR TITLE
[P4] Subtitle and data stream whitelists

### DIFF
--- a/ffmpeg_tools/codecs.py
+++ b/ffmpeg_tools/codecs.py
@@ -2,6 +2,14 @@ import enum
 
 from . import validation
 
+DATA_STREAM_WHITELIST = [
+    'bin_data'
+]
+
+
+SUBTITLE_STREAM_WHITELIST = [
+    'subrip'
+]
 
 
 class VideoCodec(enum.Enum):

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -309,7 +309,9 @@ def replace_streams(input_file,
                     replacement_source,
                     output_file,
                     stream_type,
-                    container=None):
+                    container=None,
+                    strip_unsupported_data_streams=False,
+                    strip_unsupported_subtitle_streams=False):
 
     assert os.path.isfile(input_file)
     assert os.path.isfile(replacement_source)
@@ -320,8 +322,9 @@ def replace_streams(input_file,
         replacement_source,
         output_file,
         stream_type,
-        container)
-
+        container,
+        strip_unsupported_data_streams,
+        strip_unsupported_subtitle_streams)
     exec_cmd(cmd)
 
 
@@ -355,7 +358,9 @@ def replace_streams_command(input_file,
                             replacement_source,
                             output_file,
                             stream_type,
-                            container=None):
+                            container=None,
+                            strip_unsupported_data_streams=False,
+                            strip_unsupported_subtitle_streams=False):
     """
     Builds a ffmpeg command that can be used to create a new video file with
     all streams of a specific type replaced with streams of the same type from

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -389,6 +389,18 @@ def replace_streams_command(input_file,
             f"Should be one of: {', '.join(VALID_STREAM_TYPES)}"
         )
 
+    metadata = get_metadata_json(input_file)
+    stream_numbers_to_strip = get_list_of_streams_numbers_to_skip(
+        metadata,
+        strip_unsupported_data_streams,
+        strip_unsupported_subtitle_streams,
+    )
+
+    map_options = [
+        ["-map", f"-0:{index}"]
+        for index in stream_numbers_to_strip
+    ]
+
     cmd = [
         FFMPEG_COMMAND,
         "-nostdin",
@@ -397,6 +409,7 @@ def replace_streams_command(input_file,
         "-map", f"1:{stream_type}",
         "-map", "0",
         "-map", f"-0:{stream_type}",
+    ] + flatten_list(map_options) + [
         "-copy_unknown",
         "-c:v", "copy",
         "-c:d", "copy",

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -325,6 +325,32 @@ def replace_streams(input_file,
     exec_cmd(cmd)
 
 
+def get_list_of_streams_numbers_to_skip(
+    metadata,
+    strip_unsupported_data_streams,
+    strip_unsupported_subtitle_streams
+):
+    list_of_streams_to_skip = []
+    for stream_metadata in metadata.get('streams'):
+        if (
+            strip_unsupported_data_streams and
+            stream_metadata.get('codec_type') == 'data' and
+            stream_metadata.get('codec_name') not in
+            codecs.DATA_STREAM_WHITELIST
+        ):
+            list_of_streams_to_skip.append(stream_metadata.get('index'))
+
+        elif (
+            strip_unsupported_subtitle_streams and
+            stream_metadata.get('codec_type') == 'subtitle' and
+            stream_metadata.get('codec_name') not in
+            codecs.SUBTITLE_STREAM_WHITELIST
+        ):
+            list_of_streams_to_skip.append(stream_metadata.get('index'))
+
+    return list_of_streams_to_skip
+
+
 def replace_streams_command(input_file,
                             replacement_source,
                             output_file,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,8 +1,63 @@
+import copy
 import os
 import tempfile
 
-from unittest import TestCase
+from unittest import TestCase, mock
 import ffmpeg_tools as ffmpeg
+from ffmpeg_tools import commands
+from ffmpeg_tools.codecs import DATA_STREAM_WHITELIST, SUBTITLE_STREAM_WHITELIST
+from ffmpeg_tools.commands import get_list_of_streams_numbers_to_skip
+from tests.test_meta import example_metadata
+
+BIN_DATA_EXAMPLE_STREAM = {
+    'index': 2,
+    'codec_name': DATA_STREAM_WHITELIST[0],
+    'codec_long_name': 'binary data',
+    'profile': 'unknown',
+    'codec_type': 'data',
+    'codec_tag_string': '[6][0][0][0]',
+    'codec_tag': '0x0006',
+    'id': '0x102',
+    'r_frame_rate': '0 / 0',
+    'avg_frame_rate': '0 / 0',
+    'time_base': 1 / 90000,
+    'start_pts': 131920,
+    'start_time': 1.465778,
+    'duration_ts': 475200,
+    'duration': 5.280000,
+    'bit_rate': 'N/A',
+    'max_bit_rate': 'N/A',
+    'bits_per_raw_sample': 'N/A',
+    'nb_frames': 'N/A',
+    'nb_read_frames': 'N/A',
+    'nb_read_packets': 'N/A',
+}
+
+SUBTITLES_EXAMPLE_STREAM = {
+    'index': 3,
+    'codec_name': SUBTITLE_STREAM_WHITELIST[0],
+    'codec_long_name': 'SubRip subtitle',
+    'codec_type': 'subtitle',
+    'codec_time_base': '0/1',
+    'codec_tag_string': '[0][0][0][0]',
+    'codec_tag': '0x0000',
+    'r_frame_rate': '0/0',
+    'avg_frame_rate': '0/0',
+    'time_base': '1/1000',
+    'start_pts': 0, 'start_time': '0.000000',
+    'duration_ts': 46665,
+    'duration': '46.665000',
+    'disposition': {
+        'default': 1, 'dub': 0,
+        'original': 0, 'comment': 0,
+        'lyrics': 0, 'karaoke': 0,
+        'forced': 0,
+        'hearing_impaired': 0,
+        'visual_impaired': 0,
+        'clean_effects': 0,
+        'attached_pic': 0,
+        'timed_thumbnails': 0},
+    'tags': {'language': 'eng'}}
 
 
 class TestCommands(TestCase):
@@ -65,3 +120,83 @@ class TestCommands(TestCase):
                 "tests/resources/ForBiggerBlazes-[codec=h264].mkv",
                 "v:1",
             )
+
+    def test_replace_streams_command_removes_streams_not_in_whitelist(self):
+        with mock.patch(
+            'ffmpeg_tools.commands.get_list_of_streams_numbers_to_skip') as \
+             _get_list_of_streams_numbers_to_skip:
+            _get_list_of_streams_numbers_to_skip.return_value = [2, 3]
+
+            command = ffmpeg.commands.replace_streams_command(
+                "tests/resources/ForBiggerBlazes-[codec=h264].mp4",
+                "tests/resources/ForBiggerBlazes-[codec=h264][video-only].mkv",
+                "tests/resources/ForBiggerBlazes-[codec=h264].mkv",
+                "v",
+            )
+
+            expected_command = [
+                "ffmpeg",
+                "-nostdin",
+                "-i", "tests/resources/ForBiggerBlazes-[codec=h264].mp4",
+                "-i", "tests/resources/ForBiggerBlazes-[codec=h264][video-only].mkv",  # noqa pylint:disable=line-too-long
+                "-map", "1:v",
+                "-map", "0",
+                "-map", "-0:v",
+                '-map', '-0:2',
+                '-map', '-0:3',
+                "-copy_unknown",
+                "-c:v", "copy",
+                "-c:d", "copy",
+                "tests/resources/ForBiggerBlazes-[codec=h264].mkv",
+            ]
+            self.assertEqual(command, expected_command)
+
+
+class TestGetListOfStreamsNumbersToSkip(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.metadata_without_unsupported_streams = copy.deepcopy(
+            example_metadata)
+        self.metadata_without_unsupported_streams['streams'].extend(
+            [BIN_DATA_EXAMPLE_STREAM, SUBTITLES_EXAMPLE_STREAM])
+        self.metadata_without_unsupported_streams['format']['nb_streams'] = 4
+
+        self.metadata_with_unsupported_streams = copy.deepcopy(
+            self.metadata_without_unsupported_streams)
+
+        assert 'some default unsupported name' not in BIN_DATA_EXAMPLE_STREAM
+        assert 'some default unsupported name' not in SUBTITLES_EXAMPLE_STREAM
+
+        self.metadata_with_unsupported_streams['streams'][2]['codec_name'] = \
+            'some default unsupported name'
+        self.metadata_with_unsupported_streams['streams'][3]['codec_name'] = \
+            'some default unsupported name'
+
+    def test_function_does_not_strip_whitelisted_streams(self):
+        stream_number = get_list_of_streams_numbers_to_skip(
+            self.metadata_without_unsupported_streams,
+            strip_unsupported_data_streams=True,
+            strip_unsupported_subtitle_streams=True)
+        self.assertEqual(stream_number, [])
+
+    def test_function_strips_non_whitelisted_streams(self):
+        stream_number = get_list_of_streams_numbers_to_skip(
+            self.metadata_with_unsupported_streams,
+            strip_unsupported_data_streams=True,
+            strip_unsupported_subtitle_streams=True)
+        self.assertEqual(stream_number, [2, 3])
+
+    def test_function_returns_correct_numbers_streams_metadata(self):
+        stream_number = get_list_of_streams_numbers_to_skip(
+            self.metadata_with_unsupported_streams,
+            strip_unsupported_data_streams=True,
+            strip_unsupported_subtitle_streams=True)
+        self.assertEqual(stream_number, [2, 3])
+
+    def test_function_returns_does_not_check_streams_if_not_specified(self):
+        stream_number = get_list_of_streams_numbers_to_skip(
+            self.metadata_with_unsupported_streams,
+            strip_unsupported_data_streams=False,
+            strip_unsupported_subtitle_streams=False)
+        self.assertEqual(stream_number, [])


### PR DESCRIPTION
This pull request lets user have `replace_streams_command()` tell ffmpeg to discard `data` or `subtitle` other than the ones we know ffmpeg can properly handle in conversions. By default nothing is stripped because we want to preserve as much as possible. When enabled, the feature strips anything that's not on our whitelist.

### Notes
1) Currently only `bin_data` and `subrip` streams are whitelisted. We'll likely have to tweak this list a bit later.

### Dependencies
This pull request is based on #12 and should be merged after it. This is just for ease or development and it could be rebased directly on `master` if needed.

**NOTE**: I have set the base branch of this pull request to `audio-channel-layout-validations` (#12). Please remember to change the base branch back to master before you merge.