### PR TITLE
VideoCodec.can_convert()

### DIFF
--- a/ffmpeg_tools/codecs.py
+++ b/ffmpeg_tools/codecs.py
@@ -52,6 +52,9 @@ class VideoCodec(enum.Enum):
     def get_supported_conversions(self):
         return _VIDEO_SUPPORTED_CONVERSIONS.get(self.value, [])
 
+    def can_convert(self, video_codec_value):
+        return video_codec_value in self.get_supported_conversions()
+
 
 class AudioCodec(enum.Enum):
     AAC = "aac"        # AAC (Advanced Audio Coding)

--- a/ffmpeg_tools/codecs.py
+++ b/ffmpeg_tools/codecs.py
@@ -2,6 +2,14 @@ import enum
 
 from . import validation
 
+DATA_STREAM_WHITELIST = [
+    'bin_data'
+]
+
+
+SUBTITLE_STREAM_WHITELIST = [
+    'subrip'
+]
 
 
 class VideoCodec(enum.Enum):

--- a/ffmpeg_tools/codecs.py
+++ b/ffmpeg_tools/codecs.py
@@ -135,8 +135,17 @@ _VIDEO_SUPPORTED_CONVERSIONS = {
 }
 
 _AUDIO_SUPPORTED_CONVERSIONS = {
-    "aac": [ "aac" ],
-    "mp3": [ "mp3" ],
+    #          "aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8", "wmapro", "wmav2", "vorbis"
+    "aac":    ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "ac3":    ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "amr_nb": ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "mp2":    ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "mp3":    ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "opus":   ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "pcm_u8": ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "wmapro": ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "wmav2":  ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
+    "vorbis": ["aac", "ac3", "amr_nb", "mp2", "mp3", "opus", "pcm_u8",           "wmav2", "vorbis"],
 }
 
 

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -309,7 +309,9 @@ def replace_streams(input_file,
                     replacement_source,
                     output_file,
                     stream_type,
-                    container=None):
+                    container=None,
+                    strip_unsupported_data_streams=False,
+                    strip_unsupported_subtitle_streams=False):
 
     assert os.path.isfile(input_file)
     assert os.path.isfile(replacement_source)
@@ -320,8 +322,9 @@ def replace_streams(input_file,
         replacement_source,
         output_file,
         stream_type,
-        container)
-
+        container,
+        strip_unsupported_data_streams,
+        strip_unsupported_subtitle_streams)
     exec_cmd(cmd)
 
 
@@ -355,7 +358,9 @@ def replace_streams_command(input_file,
                             replacement_source,
                             output_file,
                             stream_type,
-                            container=None):
+                            container=None,
+                            strip_unsupported_data_streams=False,
+                            strip_unsupported_subtitle_streams=False):
     """
     Builds a ffmpeg command that can be used to create a new video file with
     all streams of a specific type replaced with streams of the same type from

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -389,6 +389,18 @@ def replace_streams_command(input_file,
             f"Should be one of: {', '.join(VALID_STREAM_TYPES)}"
         )
 
+    metadata = get_metadata_json(input_file)
+    stream_numbers_to_strip = get_list_of_streams_numbers_to_skip(
+        metadata,
+        strip_unsupported_data_streams,
+        strip_unsupported_subtitle_streams,
+    )
+
+    map_options = [
+        ["-map", f"-0:{index}"]
+        for index in stream_numbers_to_strip
+    ]
+
     cmd = [
         FFMPEG_COMMAND,
         "-nostdin",
@@ -397,6 +409,7 @@ def replace_streams_command(input_file,
         "-map", f"1:{stream_type}",
         "-map", "0",
         "-map", f"-0:{stream_type}",
+    ] + flatten_list(map_options) + [
         "-copy_unknown",
         "-c:v", "copy",
         "-c:d", "copy",

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -325,6 +325,32 @@ def replace_streams(input_file,
     exec_cmd(cmd)
 
 
+def get_list_of_streams_numbers_to_skip(
+    metadata,
+    strip_unsupported_data_streams,
+    strip_unsupported_subtitle_streams
+):
+    list_of_streams_to_skip = []
+    for stream_metadata in metadata.get('streams'):
+        if (
+            strip_unsupported_data_streams and
+            stream_metadata.get('codec_type') == 'data' and
+            stream_metadata.get('codec_name') not in
+            codecs.DATA_STREAM_WHITELIST
+        ):
+            list_of_streams_to_skip.append(stream_metadata.get('index'))
+
+        elif (
+            strip_unsupported_subtitle_streams and
+            stream_metadata.get('codec_type') == 'subtitle' and
+            stream_metadata.get('codec_name') not in
+            codecs.SUBTITLE_STREAM_WHITELIST
+        ):
+            list_of_streams_to_skip.append(stream_metadata.get('index'))
+
+    return list_of_streams_to_skip
+
+
 def replace_streams_command(input_file,
                             replacement_source,
                             output_file,

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -331,7 +331,7 @@ assert set(_CONTAINER_SUPPORTED_CODECS) & {d.value for d in _EXCLUSIVE_DEMUXERS}
 
 _resolutions = {
     "16:9": [
-        [640, 260],
+        [640, 360],
         [1280, 720],
         [1536, 864],
         [1920, 1080],

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -330,39 +330,6 @@ _CONTAINER_SUPPORTED_CODECS = {
 assert set(_CONTAINER_SUPPORTED_CODECS) & {d.value for d in _EXCLUSIVE_DEMUXERS} == set(), \
     "Supported codecs for exclusive demuxers can be determined automatically; no need to define them here"
 
-_resolutions = {
-    "16:9": [
-        [640, 360],
-        [1280, 720],
-        [1536, 864],
-        [1920, 1080],
-        [2048, 1152],
-        [2560, 1440],
-        [3840, 2160],
-        [1366, 768],
-        [1360, 768]
-    ],
-    "4:3": [
-        [320, 240],
-        [640, 480],
-        [800, 600],
-        [1024, 768]
-    ],
-    "16:10": [
-        [1280, 800],
-        [1440, 900],
-        [1680, 1050],
-        [1920, 1200]
-    ],
-    "5:4": [
-        [1280, 1024]
-    ],
-    "21:9": [
-        [2560, 1080],
-        [3440, 1440]
-    ]
-}
-
 _aspect_ratio_overrides = {
     "16:9": [
         [1366, 768],
@@ -448,13 +415,6 @@ def _list_supported_audio_codecs_for_exclusive_demuxer(demuxer: Container):
         for muxer in demuxer.get_matching_muxers()
         for codec in muxer.get_supported_audio_codecs()
     ))
-
-
-def list_matching_resolutions(resolution):
-    for aspect, resolutions_list in _resolutions.items():
-        if resolution in resolutions_list:
-            return resolutions_list
-    return [resolution]
 
 
 def get_effective_aspect_ratio(resolution: list) -> str:

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -1,4 +1,5 @@
 import enum
+from math import gcd
 
 from . import validation
 from . import codecs
@@ -362,6 +363,17 @@ _resolutions = {
     ]
 }
 
+_aspect_ratio_overrides = {
+    "16:9": [
+        [1366, 768],
+        [1360, 768]
+    ],
+    "21:9": [
+        [2560, 1080],
+        [3440, 1440]
+    ]
+}
+
 _frame_rates = {
     # NOTE 1: The same frame rate can often be represented a few slightly
     # different ways. For example 24 FPS could be 24, '24', '24/1', '48/2'
@@ -443,6 +455,19 @@ def list_matching_resolutions(resolution):
         if resolution in resolutions_list:
             return resolutions_list
     return [resolution]
+
+
+def get_effective_aspect_ratio(resolution: list) -> str:
+    for aspect, resolutions_list in _aspect_ratio_overrides.items():
+        if resolution in resolutions_list:
+            return aspect
+    return calculate_aspect_ratio(resolution)
+
+
+def calculate_aspect_ratio(resolution: list) -> str:
+    assert len(resolution) == 2
+    resolution_gcd = gcd(resolution[0], resolution[1])
+    return f"{resolution[0] // resolution_gcd}:{resolution[1] // resolution_gcd}"
 
 
 def list_supported_frame_rates():

--- a/ffmpeg_tools/meta.py
+++ b/ffmpeg_tools/meta.py
@@ -48,6 +48,13 @@ def get_format(metadata):
     return metadata["format"]["format_name"]
 
 
+def get_audio_stream(metadata):
+    for stream in metadata['streams']:
+        if stream["codec_type"] == "audio":
+            return stream
+    return None
+
+
 def create_params(vformat, resolution, vcodec, acodec=None,
                   frame_rate=None, video_bitrate=None,
                   audio_bitrate=None, scaling_algorithm=None):

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -5,7 +5,7 @@ from . import formats
 from . import codecs
 
 
-
+_MAX_SUPPORTED_AUDIO_CHANNELS = 2
 
 
 class InvalidVideo(Exception):
@@ -64,6 +64,14 @@ class UnsupportedAudioCodecConversion(InvalidVideo):
         super().__init__(message="Unsupported audio codec conversion from {} to {}".format(src_codec, dst_codec))
 
 
+class UnsupportedAudioChannelLayout(InvalidVideo):
+    def __init__(self, audio_channels):
+        super().__init__(
+            message="Unsupported audio channel layout conversion. "
+                    "Unable to reliably preserve the {}-channel audio found "
+                    "in the input file in combination with other target parameters.".format(audio_channels)
+        )
+
 
 def validate_video(metadata):
     try:
@@ -98,7 +106,11 @@ def validate_transcoding_params(src_params, dst_params, src_metadata):
     try:
         validate_audio_codec(src_params["format"], src_params["audio"]["codec"])
         validate_audio_codec(dst_params["format"], dst_params["audio"]["codec"])
-        validate_audio_codec_conversion(src_params["audio"]["codec"], dst_params["audio"]["codec"])
+        validate_audio_codec_conversion(
+            src_params["audio"]["codec"],
+            dst_params["audio"]["codec"],
+            meta.get_audio_stream(src_metadata)
+        )
     except KeyError as _:
         # We accept only KeyError, because it means, there were now value
         # in dictionary. Note that validate functions can still throw other
@@ -222,8 +234,15 @@ def validate_video_codec_conversion(src_codec, dst_codec):
     return True
 
 
-def validate_audio_codec_conversion(src_codec, dst_codec):
+def validate_audio_codec_conversion(src_codec, dst_codec, audio_stream):
     codec = codecs.AudioCodec(src_codec)
     if dst_codec not in codec.get_supported_conversions():
         raise UnsupportedAudioCodecConversion(src_codec, dst_codec)
+    if src_codec != dst_codec and \
+            audio_stream['channels'] > _MAX_SUPPORTED_AUDIO_CHANNELS:
+        # Multi-channel audio is not supported by all audio codecs.
+        # We want to avoid creating another list to keep this information,
+        # so we’ll just assume that if we found multi-channel audio in the input,
+        # it’s OK and otherwise it’s not supported.
+        raise UnsupportedAudioChannelLayout(audio_stream['channels'])
     return True

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -81,7 +81,7 @@ def validate_video(metadata):
     return True
 
 
-def validate_transcoding_params(src_params, dst_params):
+def validate_transcoding_params(src_params, dst_params, src_metadata):
 
     # Validate format
     validate_format(src_params["format"])

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -217,13 +217,13 @@ def validate_frame_rate(src_frame_rate, target_frame_rate):
 
 def validate_video_codec_conversion(src_codec, dst_codec):
     codec = codecs.VideoCodec(src_codec)
-    if not dst_codec in codec.get_supported_conversions():
+    if dst_codec not in codec.get_supported_conversions():
         raise UnsupportedVideoCodecConversion(src_codec, dst_codec)
     return True
 
 
 def validate_audio_codec_conversion(src_codec, dst_codec):
     codec = codecs.AudioCodec(src_codec)
-    if not dst_codec in codec.get_supported_conversions():
+    if dst_codec not in codec.get_supported_conversions():
         raise UnsupportedAudioCodecConversion(src_codec, dst_codec)
     return True

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -192,9 +192,14 @@ def validate_audio_codec(video_format, audio_codec):
 
 
 def validate_resolution(src_resolution, target_resolution):
-    if not target_resolution in formats.list_matching_resolutions(src_resolution):
-        raise InvalidResolution(src_resolution, target_resolution)
-    return True
+    """
+    Validate if aspect ratio of source resolution and
+    target resolution are the same.
+    """
+    if formats.get_effective_aspect_ratio(src_resolution) == \
+            formats.get_effective_aspect_ratio(target_resolution):
+        return True
+    raise InvalidResolution(src_resolution, target_resolution)
 
 
 def validate_frame_rate(src_frame_rate, target_frame_rate):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ tests_require = [
 
 setuptools.setup(
     name='ffmpeg-tools',
-    version='0.15.0',
+    version='0.16.0',
     description="Tools for using ffmpeg functionalities in python.",
     url='https://github.com/golemfactory/ffmpeg-tools',
     maintainer='The Golem Team',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,10 @@
 import setuptools
 
+
+tests_require = [
+    'pytest'
+]
+
 setuptools.setup(
     name='ffmpeg-tools',
     version='0.14.1',
@@ -9,6 +14,6 @@ setuptools.setup(
     maintainer_email='tech@golem.network',
     packages=setuptools.find_packages(exclude=["tests/"]),
     python_requires='>=3.5',
-    zip_safe=False
+    zip_safe=False,
+    tests_require=tests_require,
 )
-

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ import setuptools
 
 
 tests_require = [
-    'pytest'
+    'pytest',
+    'parameterized',
 ]
 
 setuptools.setup(

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -5,7 +5,6 @@ from unittest import TestCase
 import ffmpeg_tools as ffmpeg
 
 
-
 class TestSupportedConversions(TestCase):
 
     def test_list_video_conversion(self):
@@ -19,6 +18,14 @@ class TestSupportedConversions(TestCase):
 
     def test_list_audio_conversion_invalid_codec(self):
         assert( len( ffmpeg.codecs.list_supported_audio_conversions("blabla") ) == 0 )
+
+    def test_can_convert_correct_video_codec(self):
+        assert "h264" in ffmpeg.codecs._VIDEO_SUPPORTED_CONVERSIONS["h264"]
+        self.assertTrue(ffmpeg.codecs.VideoCodec("h264").can_convert("h264"))
+
+    def test_can_convert_unsupported_video_codec(self):
+        assert "msmpeg4v2" not in ffmpeg.codecs._VIDEO_SUPPORTED_CONVERSIONS["h264"]
+        self.assertFalse(ffmpeg.codecs.VideoCodec("h264").can_convert("msmpeg4v2"))
 
 
 class TestGettingEncoder(TestCase):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,8 +1,63 @@
+import copy
 import os
 import tempfile
 
-from unittest import TestCase
+from unittest import TestCase, mock
 import ffmpeg_tools as ffmpeg
+from ffmpeg_tools import commands
+from ffmpeg_tools.codecs import DATA_STREAM_WHITELIST, SUBTITLE_STREAM_WHITELIST
+from ffmpeg_tools.commands import get_list_of_streams_numbers_to_skip
+from tests.test_meta import example_metadata
+
+BIN_DATA_EXAMPLE_STREAM = {
+    'index': 2,
+    'codec_name': DATA_STREAM_WHITELIST[0],
+    'codec_long_name': 'binary data',
+    'profile': 'unknown',
+    'codec_type': 'data',
+    'codec_tag_string': '[6][0][0][0]',
+    'codec_tag': '0x0006',
+    'id': '0x102',
+    'r_frame_rate': '0 / 0',
+    'avg_frame_rate': '0 / 0',
+    'time_base': 1 / 90000,
+    'start_pts': 131920,
+    'start_time': 1.465778,
+    'duration_ts': 475200,
+    'duration': 5.280000,
+    'bit_rate': 'N/A',
+    'max_bit_rate': 'N/A',
+    'bits_per_raw_sample': 'N/A',
+    'nb_frames': 'N/A',
+    'nb_read_frames': 'N/A',
+    'nb_read_packets': 'N/A',
+}
+
+SUBTITLES_EXAMPLE_STREAM = {
+    'index': 3,
+    'codec_name': SUBTITLE_STREAM_WHITELIST[0],
+    'codec_long_name': 'SubRip subtitle',
+    'codec_type': 'subtitle',
+    'codec_time_base': '0/1',
+    'codec_tag_string': '[0][0][0][0]',
+    'codec_tag': '0x0000',
+    'r_frame_rate': '0/0',
+    'avg_frame_rate': '0/0',
+    'time_base': '1/1000',
+    'start_pts': 0, 'start_time': '0.000000',
+    'duration_ts': 46665,
+    'duration': '46.665000',
+    'disposition': {
+        'default': 1, 'dub': 0,
+        'original': 0, 'comment': 0,
+        'lyrics': 0, 'karaoke': 0,
+        'forced': 0,
+        'hearing_impaired': 0,
+        'visual_impaired': 0,
+        'clean_effects': 0,
+        'attached_pic': 0,
+        'timed_thumbnails': 0},
+    'tags': {'language': 'eng'}}
 
 
 class TestCommands(TestCase):
@@ -65,3 +120,83 @@ class TestCommands(TestCase):
                 "tests/resources/ForBiggerBlazes-[codec=h264].mkv",
                 "v:1",
             )
+
+    def test_replace_streams_command_removes_streams_not_in_whitelist(self):
+        with mock.patch(
+            'ffmpeg_tools.commands.get_list_of_streams_numbers_to_skip') as \
+             _get_list_of_streams_numbers_to_skip:
+            _get_list_of_streams_numbers_to_skip.return_value = [2, 3]
+
+            command = ffmpeg.commands.replace_streams_command(
+                "tests/resources/ForBiggerBlazes-[codec=h264].mp4",
+                "tests/resources/ForBiggerBlazes-[codec=h264][video-only].mkv",
+                "tests/resources/ForBiggerBlazes-[codec=h264].mkv",
+                "v",
+            )
+
+            expected_command = [
+                "ffmpeg",
+                "-nostdin",
+                "-i", "tests/resources/ForBiggerBlazes-[codec=h264].mp4",
+                "-i", "tests/resources/ForBiggerBlazes-[codec=h264][video-only].mkv",  # noqa pylint:disable=line-too-long
+                "-map", "1:v",
+                "-map", "0",
+                "-map", "-0:v",
+                '-map', '-0:2',
+                '-map', '-0:3',
+                "-copy_unknown",
+                "-c:v", "copy",
+                "-c:d", "copy",
+                "tests/resources/ForBiggerBlazes-[codec=h264].mkv",
+            ]
+            self.assertEqual(command, expected_command)
+
+
+class TestGetListOfStreamsNumbersToSkip(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.metadata_without_unsupported_streams = copy.deepcopy(
+            example_metadata)
+        self.metadata_without_unsupported_streams['streams'].extend(
+            [BIN_DATA_EXAMPLE_STREAM, SUBTITLES_EXAMPLE_STREAM])
+        self.metadata_without_unsupported_streams['format']['nb_streams'] = 4
+
+        self.metadata_with_unsupported_streams = copy.deepcopy(
+            self.metadata_without_unsupported_streams)
+
+        assert 'some default unsupported name' not in BIN_DATA_EXAMPLE_STREAM
+        assert 'some default unsupported name' not in SUBTITLES_EXAMPLE_STREAM
+
+        self.metadata_with_unsupported_streams['streams'][2]['codec_name'] = \
+            'some default unsupported name'
+        self.metadata_with_unsupported_streams['streams'][3]['codec_name'] = \
+            'some default unsupported name'
+
+    def test_function_does_not_strip_whitelisted_streams(self):
+        stream_number = get_list_of_streams_numbers_to_skip(
+            self.metadata_without_unsupported_streams,
+            strip_unsupported_data_streams=True,
+            strip_unsupported_subtitle_streams=True)
+        self.assertEqual(stream_number, [])
+
+    def test_function_strips_non_whitelisted_streams(self):
+        stream_number = get_list_of_streams_numbers_to_skip(
+            self.metadata_with_unsupported_streams,
+            strip_unsupported_data_streams=True,
+            strip_unsupported_subtitle_streams=True)
+        self.assertEqual(stream_number, [2, 3])
+
+    def test_function_returns_correct_numbers_streams_metadata(self):
+        stream_number = get_list_of_streams_numbers_to_skip(
+            self.metadata_with_unsupported_streams,
+            strip_unsupported_data_streams=True,
+            strip_unsupported_subtitle_streams=True)
+        self.assertEqual(stream_number, [2, 3])
+
+    def test_function_returns_does_not_check_streams_if_not_specified(self):
+        stream_number = get_list_of_streams_numbers_to_skip(
+            self.metadata_with_unsupported_streams,
+            strip_unsupported_data_streams=False,
+            strip_unsupported_subtitle_streams=False)
+        self.assertEqual(stream_number, [])

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -144,24 +144,6 @@ class TestSupportedAudioCodecs(object):
         assert not container.is_supported_audio_codec("bla")
 
 
-class TestResolutionsTools(object):
-
-    def test_listing(self):
-        resolution_list = ffmpeg.formats.list_matching_resolutions( [1920, 1080] )
-        assert( len( resolution_list ) > 2 )
-
-    def test_listing2(self):
-        resolution_list = ffmpeg.formats.list_matching_resolutions( [1280, 720] )
-        assert( len( resolution_list ) > 2 )
-
-    def test_listing_bad_propotions(self):
-        resolution_list = ffmpeg.formats.list_matching_resolutions( [2, 1] )
-
-        # Function returns at least resolution, that was passed in parameter.
-        assert( len( resolution_list ) == 1 )
-
-
-
 class TestHelperFunctions(TestCase):
 
     def test_get_safe_intermediate_format_for_demuxer(self):

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -3,6 +3,7 @@ import pytest
 from unittest import TestCase
 
 import ffmpeg_tools as ffmpeg
+from parameterized import parameterized
 
 
 class TestContainer(TestCase):
@@ -142,6 +143,36 @@ class TestSupportedAudioCodecs(object):
         assert container.is_supported_audio_codec(acodec)
         assert container.is_supported_audio_codec(acodec_class)
         assert not container.is_supported_audio_codec("bla")
+
+
+class TestAspectRatioCalculations(TestCase):
+
+    @parameterized.expand([
+        ([333, 333], "1:1"),
+        ([333, 666], "1:2"),
+        ([1366, 768], "16:9"),
+        ([1360, 768], "16:9"),
+        ([1920, 1080], "16:9"),
+        ([2560, 1080], "21:9"),
+        ([3440, 1440], "21:9"),
+    ])
+    def test_effective_aspect_ratio(self, resolution, expected_aspect_ratio):
+        aspect_ratio = ffmpeg.formats.get_effective_aspect_ratio(resolution)
+        self.assertEqual(aspect_ratio, expected_aspect_ratio)
+
+    @parameterized.expand([
+        ([333, 666], "1:2"),
+        ([1024, 768], "4:3"),
+        ([1920, 1080], "16:9"),
+        ([1280, 1024], "5:4"),
+        ([1360, 768], "85:48"),
+        ([1366, 768], "683:384"),
+        ([2560, 1080], "64:27"),
+        ([3440, 1440], "43:18"),
+    ])
+    def test_calculate_aspect_ratio(self, resolution, expected_aspect_ratio):
+        aspect_ratio = ffmpeg.formats.calculate_aspect_ratio(resolution)
+        self.assertEqual(aspect_ratio, expected_aspect_ratio)
 
 
 class TestHelperFunctions(TestCase):

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -117,6 +117,9 @@ class TestMetadata(object):
     def test_get_format(self):
         assert(ffmpeg.meta.get_format(example_metadata) == "matroska,webm" )
 
+    def test_get_audio_stream(self):
+        assert (ffmpeg.meta.get_audio_stream(example_metadata) == example_metadata['streams'][1])
+
     def test_get_metadata_invalid_path(self):
         assert(ffmpeg.meta.get_metadata("blabla") == {})
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -226,6 +226,13 @@ class TestInputValidation(TestCase):
 
 class TestConversionValidation(TestCase):
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._metadata = get_metadata("tests/resources/ForBiggerBlazes-[codec=h264].mp4")
+
+    def setUp(self) -> None:
+        pass
+
     @staticmethod
     def create_params(container, resolution, vcodec, acodec=None):
         return meta.create_params(container, resolution, vcodec, acodec=acodec)
@@ -235,29 +242,28 @@ class TestConversionValidation(TestCase):
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mov", [1920, 1080], "h264", "mp3" )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
 
 
     def test_video_codec_change(self):
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [1920, 1080], "h265", "mp3" )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
 
 
     def test_invalid_audio_codec_change(self):
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "aac" )
-
         with self.assertRaises(validation.UnsupportedAudioCodecConversion):
-            validation.validate_transcoding_params(src_params, dst_params)
+            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
 
 
     def test_resolution_change(self):
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
         dst_params = self.create_params("mp4", [640, 360], "h264", "mp3" )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
 
 
     def test_no_audio_codec(self):
@@ -265,7 +271,7 @@ class TestConversionValidation(TestCase):
         src_params = self.create_params("mp4", [1920, 1080], "h264", None )
         dst_params = self.create_params("mp4", [640, 360], "h264", None )
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
 
 
     def test_invalid_src_video_codec(self):
@@ -273,7 +279,7 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
 
         with self.assertRaises(validation.UnsupportedVideoCodec):
-            validation.validate_transcoding_params(src_params, dst_params)
+            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
 
 
     def test_invalid_dst_video_codec(self):
@@ -281,7 +287,7 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [1920, 1080], "avi", "mp3" )
 
         with self.assertRaises(validation.UnsupportedVideoCodec):
-            validation.validate_transcoding_params(src_params, dst_params)
+            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
 
 
     def test_invalid_resolution_change(self):
@@ -289,7 +295,7 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [1280, 1024], "h264", "mp3" )
 
         with self.assertRaises(validation.InvalidResolution):
-            validation.validate_transcoding_params(src_params, dst_params)
+            validation.validate_transcoding_params(src_params, dst_params, self._metadata)
 
     @parameterized.expand([
         ([333, 333], [333, 333]),
@@ -307,4 +313,5 @@ class TestConversionValidation(TestCase):
         src_params = self.create_params("mp4", src_resolution, "h264", "mp3")
         dst_params = self.create_params("mp4", target_resolution, "h264", "mp3")
 
-        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -254,7 +254,7 @@ class TestConversionValidation(TestCase):
 
     def test_resolution_change(self):
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
-        dst_params = self.create_params("mp4", [640, 260], "h264", "mp3" )
+        dst_params = self.create_params("mp4", [640, 360], "h264", "mp3" )
 
         self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
 
@@ -262,7 +262,7 @@ class TestConversionValidation(TestCase):
     def test_no_audio_codec(self):
         # It is valid to not provide audio codec.
         src_params = self.create_params("mp4", [1920, 1080], "h264", None )
-        dst_params = self.create_params("mp4", [640, 260], "h264", None )
+        dst_params = self.create_params("mp4", [640, 360], "h264", None )
 
         self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -293,6 +293,9 @@ class TestConversionValidation(TestCase):
 
     @parameterized.expand([
         ([333, 333], [333, 333]),
+        ([333, 666], [666, 1332]),
+        ([1920, 1080], [1366, 768]),
+        ([3840, 2160], [2560, 1440]),
     ])
     def test_nonstandard_resolution_change(
             self,

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -8,6 +8,7 @@ from ffmpeg_tools.validation import UnsupportedVideoCodec, UnsupportedVideoForma
     UnsupportedTargetVideoFormat, MissingVideoStream, UnsupportedAudioCodec, \
     InvalidVideo, MissingVideoStream, InvalidFormatMetadata
 
+import ffmpeg_tools.codecs as codecs
 import ffmpeg_tools.validation as validation
 import ffmpeg_tools.formats as formats
 import ffmpeg_tools.meta as meta
@@ -254,9 +255,10 @@ class TestConversionValidation(TestCase):
 
 
     def test_invalid_audio_codec_change(self):
+        assert codecs.AudioCodec.WMAPRO.value not in codecs.AudioCodec.MP3.get_supported_conversions()
         src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3" )
-        dst_params = self.create_params("mp4", [1920, 1080], "h264", "aac" )
-        with self.assertRaises(validation.UnsupportedAudioCodecConversion):
+        dst_params = self.create_params("mp4", [1920, 1080], "h264", "wmapro" )
+        with self.assertRaises(validation.UnsupportedAudioCodec):
             validation.validate_transcoding_params(src_params, dst_params, self._metadata)
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -10,6 +10,7 @@ from ffmpeg_tools.validation import UnsupportedVideoCodec, UnsupportedVideoForma
 import ffmpeg_tools.validation as validation
 import ffmpeg_tools.formats as formats
 import ffmpeg_tools.meta as meta
+from parameterized import parameterized
 
 
 class TestInputValidation(TestCase):
@@ -290,11 +291,17 @@ class TestConversionValidation(TestCase):
         with self.assertRaises(validation.InvalidResolution):
             validation.validate_transcoding_params(src_params, dst_params)
 
-
-    def test_nonstandard_resolution_change(self):
+    @parameterized.expand([
+        ([333, 333], [333, 333]),
+    ])
+    def test_nonstandard_resolution_change(
+            self,
+            src_resolution,
+            target_resolution,
+    ):
         # It is allowed to convert video with non standard resolution
         # to the same resolution.
-        src_params = self.create_params("mp4", [333, 333], "h264", "mp3" )
-        dst_params = self.create_params("mp4", [333, 333], "h264", "mp3" )
+        src_params = self.create_params("mp4", src_resolution, "h264", "mp3")
+        dst_params = self.create_params("mp4", target_resolution, "h264", "mp3")
 
         self.assertTrue(validation.validate_transcoding_params(src_params, dst_params))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,3 +1,4 @@
+import copy
 from unittest import TestCase
 import sys
 
@@ -315,3 +316,18 @@ class TestConversionValidation(TestCase):
 
         self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, self._metadata))
 
+    def test_validate_audio_conversion_with_more_than_two_audio_channels(self):
+        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3")
+        dst_params = self.create_params("mp4", [1920, 1080], "h264", "aac")
+        unsupported_metadata = copy.deepcopy(self._metadata)
+        unsupported_metadata['streams'][1]['channels'] = validation._MAX_SUPPORTED_AUDIO_CHANNELS + 1
+        with self.assertRaises(validation.UnsupportedAudioChannelLayout):
+            validation.validate_transcoding_params(src_params, dst_params, unsupported_metadata)
+
+    def test_validate_conversion_without_audio_that_have_more_than_two_audio_channels(self):
+        src_params = self.create_params("mp4", [1920, 1080], "h264", "mp3")
+        dst_params = self.create_params("mp4", [1920, 1080], "h265", "mp3")
+        unsupported_metadata = copy.deepcopy(self._metadata)
+        unsupported_metadata['streams'][1]['channels'] = validation._MAX_SUPPORTED_AUDIO_CHANNELS + 1
+
+        self.assertTrue(validation.validate_transcoding_params(src_params, dst_params, unsupported_metadata))


### PR DESCRIPTION
This pull request adds `can_convert()` method to `VideoCodec` to slightly improve the API of the library and make code more readable. Requested in one of the pull requests in Golem.

### Dependencies
This pull request is based on #15 and should be merged after it. This is just for ease or development and it could be rebased directly on `master` if needed.

**NOTE**: I have set the base branch of this pull request to `task-p3-p4-skip-streams-which-are-not-supported-by-other-containers` (#15). Please remember to change the base branch back to master before you merge.