### PR TITLE
[P3] Validations for subtitle and data stream whitelists

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -153,7 +153,7 @@ class TestCommands(TestCase):
             self.assertEqual(command, expected_command)
 
 
-class TestGetListOfStreamsNumbersToSkip(TestCase):
+class MetadataWithSupportedAndUnsupportedStreamsBase(TestCase):
 
     def setUp(self):
         super().setUp()
@@ -173,6 +173,11 @@ class TestGetListOfStreamsNumbersToSkip(TestCase):
             'some default unsupported name'
         self.metadata_with_unsupported_streams['streams'][3]['codec_name'] = \
             'some default unsupported name'
+
+
+class TestGetListOfStreamNumbersToSkip(
+    MetadataWithSupportedAndUnsupportedStreamsBase
+):
 
     def test_function_does_not_strip_whitelisted_streams(self):
         stream_number = get_lists_of_unsupported_stream_numbers(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -2,6 +2,8 @@ import copy
 from unittest import TestCase
 import sys
 
+from tests.test_commands import MetadataWithSupportedAndUnsupportedStreamsBase
+
 from ffmpeg_tools.formats import list_supported_formats, list_supported_video_codecs, list_supported_audio_codecs
 from ffmpeg_tools.meta import get_metadata
 from ffmpeg_tools.validation import UnsupportedVideoCodec, UnsupportedVideoFormat, \
@@ -343,3 +345,37 @@ class TestConversionValidation(TestCase):
         unsupported_metadata['streams'][1]['channels'] = validation._MAX_SUPPORTED_AUDIO_CHANNELS + 1
 
         self.assertTrue(validation.validate_transcoding_params(dst_params, unsupported_metadata))
+
+
+class TestValidateUnsupportedStreams(
+    MetadataWithSupportedAndUnsupportedStreamsBase
+):
+
+    def test_function_raises_exception_if_unsupported_stream_with_no_strip(self):
+        with self.assertRaises(validation.UnsupportedStream):
+            validation.validate_data_and_subtitle_streams(
+                metadata=self.metadata_with_unsupported_streams,
+                strip_unsupported_data_streams=False,
+                strip_unsupported_subtitle_streams=False,
+            )
+
+    def test_function_passes_if_unsupported_stream_strip_streams_is_true(self):
+        validation.validate_data_and_subtitle_streams(
+            metadata=self.metadata_with_unsupported_streams,
+            strip_unsupported_data_streams=True,
+            strip_unsupported_subtitle_streams=True,
+        )
+
+    def test_function_passes_if_only_supported_streams_strip_is_false(self):
+        validation.validate_data_and_subtitle_streams(
+            metadata=self.metadata_without_unsupported_streams,
+            strip_unsupported_data_streams=False,
+            strip_unsupported_subtitle_streams=False,
+        )
+
+    def test_function_passes_if_only_supported_streams_strip_is_true(self):
+        validation.validate_data_and_subtitle_streams(
+            metadata=self.metadata_without_unsupported_streams,
+            strip_unsupported_data_streams=True,
+            strip_unsupported_subtitle_streams=True,
+        )


### PR DESCRIPTION
This pull request extends data and subtitle stream validations to make them detect unsupported stream types in the input video. This happens before transcoding starts instead of letting it crash at the merge step. The checks can be skipped if user requests the streams to be automatically removed by setting  `strip_unsupported_data_streams` and/or `strip_unsupported_subtitle_streams` in task parameters to `True`.

### API compatibility
The API is backwards compatible because the parameters newly added to validations have default values.

### Dependencies
This pull request has no dependencies. It's directly on `master`.