### PR TITLE
Miscellaneous fixes and refactoring before task O4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-ffmpeg_tools/__pycache__
-tests/__pycache__
-.pytest_cache
-ffmpeg_tools.egg-info
-build/
-dist/
+# Files cached by Python and tools
+__pycache__/
+.pytest_cache/
 .cache
+
+# Build artifacts
+/ffmpeg_tools.egg-info
+/build/
+/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 .pytest_cache/
 .cache
+/.mypy_cache/
 
 # Build artifacts
 /ffmpeg_tools.egg-info

--- a/ffmpeg_tools/codecs.py
+++ b/ffmpeg_tools/codecs.py
@@ -1,4 +1,5 @@
 import enum
+from typing import List, Optional
 
 from . import exceptions
 from . import frame_rate
@@ -48,13 +49,13 @@ class VideoCodec(enum.Enum):
 
     # FFMPEG needs encoder name, instead of codec name as transcoding parameter.
     # If list doesn't contain encoder we assume that we can pass codec name.
-    def get_encoder(self):
+    def get_encoder(self) -> Optional[str]:
         return _VIDEO_ENCODERS.get(self.value, self.value)
 
-    def get_supported_conversions(self):
+    def get_supported_conversions(self) -> List[str]:
         return _VIDEO_SUPPORTED_CONVERSIONS.get(self.value, [])
 
-    def can_convert(self, video_codec_value):
+    def can_convert(self, video_codec_value: str) -> bool:
         return video_codec_value in self.get_supported_conversions()
 
 
@@ -84,12 +85,11 @@ class AudioCodec(enum.Enum):
 
     # FFMPEG needs encoder name, instead of codec name as transcoding parameter.
     # If list doesn't contain encoder we assume that we can pass codec name.
-    def get_encoder(self):
+    def get_encoder(self) -> Optional[str]:
         return _AUDIO_ENCODERS.get(self.value, self.value)
 
-    def get_supported_conversions(self):
+    def get_supported_conversions(self) -> List[str]:
         return _AUDIO_SUPPORTED_CONVERSIONS.get(self.value, [])
-
 
 
 _VIDEO_ENCODERS = {
@@ -169,32 +169,32 @@ _PRESERVE_QUALITY_COMMAND = {
 }
 
 
-def get_video_encoder(target_codec):
+def get_video_encoder(target_codec: str) -> Optional[str]:
     # This will throw exception for unsupported codecs.
     codec = VideoCodec(target_codec)
     return codec.get_encoder()
 
 
-def preserve_quality_command(target_codec):
+def preserve_quality_command(target_codec: str) -> List[str]:
     # TODO: Hack function to preserve video quality for some formats.
     # Create better and more generic solution in future.
     return _PRESERVE_QUALITY_COMMAND.get(target_codec, [])
 
 
-def get_audio_encoder(target_codec):
+def get_audio_encoder(target_codec: str) -> Optional[str]:
     # This will throw exception for unsupported codecs.
     codec = AudioCodec(target_codec)
     return codec.get_encoder()
 
 
-def list_supported_video_conversions(codec):
+def list_supported_video_conversions(codec: str) -> List[str]:
     if codec not in VideoCodec._value2member_map_:
         return []
 
     return VideoCodec(codec).get_supported_conversions()
 
 
-def list_supported_audio_conversions(codec):
+def list_supported_audio_conversions(codec: str) -> List[str]:
     if codec not in AudioCodec._value2member_map_:
         return []
 

--- a/ffmpeg_tools/codecs.py
+++ b/ffmpeg_tools/codecs.py
@@ -55,8 +55,8 @@ class VideoCodec(enum.Enum):
     def get_supported_conversions(self) -> List[str]:
         return _VIDEO_SUPPORTED_CONVERSIONS.get(self.value, [])
 
-    def can_convert(self, video_codec_value: str) -> bool:
-        return video_codec_value in self.get_supported_conversions()
+    def can_convert(self, video_codec: str) -> bool:
+        return video_codec in self.get_supported_conversions()
 
 
 class AudioCodec(enum.Enum):
@@ -90,6 +90,9 @@ class AudioCodec(enum.Enum):
 
     def get_supported_conversions(self) -> List[str]:
         return _AUDIO_SUPPORTED_CONVERSIONS.get(self.value, [])
+
+    def can_convert(self, audio_codec: str) -> bool:
+        return audio_codec in self.get_supported_conversions()
 
 
 _VIDEO_ENCODERS = {

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -440,9 +440,9 @@ def replace_streams_command(input_file,
         "-f", container,
     ] if container is not None else []) + ([
         "-c:a", codecs.get_audio_encoder(targs['audio']['codec']),
-    ] if 'audio' in targs and 'codec' in targs['audio'] else []) + ([
+    ] if 'codec' in targs.get('audio', {}) else []) + ([
         "-b:a", targs['audio']['bitrate'],
-    ] if 'audio' in targs and 'bitrate' in targs['audio'] else []) + [
+    ] if 'bitrate' in targs.get('audio', {}) else []) + [
         output_file,
     ]
 

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -363,8 +363,6 @@ def replace_streams_command(input_file,
             - `V` - video streams which are not attached pictures, video
                     thumbnails or cover arts.
             - `a` - audio streams.
-            - `s` - subtitle streams.
-            - `d` - data streams.
             - `t` - attachments.
     :param targs: Dictionary with additional transcoding parameters.
         The following parameters are supported:
@@ -377,7 +375,10 @@ def replace_streams_command(input_file,
         Optional, but highly recommended. If you don't specify it, ffmpeg will
         try to guess based the extension of the output file.
     """
-    VALID_STREAM_TYPES = {'v', 'V', 'a', 's', 'd', 't'}
+    # NOTE: We could support 's' (subtitle streams) or 'd' (data streams) as well
+    # but it would complicate the implementation and we currently don't use them
+    # so implementing it was not worth the hassle.
+    VALID_STREAM_TYPES = {'v', 'V', 'a', 't'}
     if stream_type not in VALID_STREAM_TYPES:
         raise exceptions.InvalidArgument(
             f"Invalid value of 'stream_type'. "

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -357,8 +357,6 @@ def replace_streams_command(input_file,
         type will be taken. Must exist.
     :param output_file: Container to put the streams in. Must not exist.
     :param stream_type: Stream type specifier.
-    :param targs: Dictionary with additional parameters used by command
-    :param container: Container of output file
         See https://ffmpeg.org/ffmpeg.html#Stream-specifiers.
         The following values are supported:
             - `v` - same as `V`.
@@ -368,6 +366,8 @@ def replace_streams_command(input_file,
             - `s` - subtitle streams.
             - `d` - data streams.
             - `t` - attachments.
+    :param targs: Dictionary with additional parameters used by command
+    :param container: Container of output file
     """
     VALID_STREAM_TYPES = {'v', 'V', 'a', 's', 'd', 't'}
     if stream_type not in VALID_STREAM_TYPES:

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -374,6 +374,16 @@ def replace_streams_command(input_file,
     :param container: Container type to use for the output file.
         Optional, but highly recommended. If you don't specify it, ffmpeg will
         try to guess based the extension of the output file.
+    :param strip_unsupported_data_streams: If true, all data streams using
+        codecs not listed in DATA_STREAM_WHITELIST will not be included in the
+        output file. If your input_file contains such streams but you don't
+        care about them, you can use this option to force a conversion that
+        would otherwise fail.
+    :param strip_unsupported_subtitle_streams: If true, all subtitle streams using
+        codecs not listed in SUBTITLE_STREAM_WHITELIST will not be included in the
+        output file. If your input_file contains such streams but you don't
+        care about them, you can use this option to force a conversion that
+        would otherwise fail.
     """
     # NOTE: We could support 's' (subtitle streams) or 'd' (data streams) as well
     # but it would complicate the implementation and we currently don't use them

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -366,8 +366,16 @@ def replace_streams_command(input_file,
             - `s` - subtitle streams.
             - `d` - data streams.
             - `t` - attachments.
-    :param targs: Dictionary with additional parameters used by command
-    :param container: Container of output file
+    :param targs: Dictionary with additional transcoding parameters.
+        The following parameters are supported:
+            - `audio`: dict with parameters for audio stream transcoding.
+                Same parameters are applied to all audio streams.
+                Transcoding different audio streams differently is currently
+                not supported.
+                Can include the following keys:`bitrate`, `codec`.
+    :param container: Container type to use for the output file.
+        Optional, but highly recommended. If you don't specify it, ffmpeg will
+        try to guess based the extension of the output file.
     """
     VALID_STREAM_TYPES = {'v', 'V', 'a', 's', 'd', 't'}
     if stream_type not in VALID_STREAM_TYPES:

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -76,11 +76,15 @@ class Container(enum.Enum):
         elif isinstance(vcodec, str):
             return vcodec in self.get_supported_video_codecs()
 
+        assert False, "Invalid type"
+
     def is_supported_audio_codec(self, acodec):
         if isinstance(acodec, codecs.AudioCodec):
             return acodec.value in self.get_supported_audio_codecs()
         elif isinstance(acodec, str):
             return acodec in self.get_supported_audio_codecs()
+
+        assert False, "Invalid type"
 
     @staticmethod
     def is_supported(vformat):

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -103,7 +103,7 @@ class Container(enum.Enum):
     def is_exclusive_demuxer(self) -> bool:
         return self in _EXCLUSIVE_DEMUXERS
 
-    def get_matching_muxers(self) -> Set[str]:
+    def get_matching_muxers(self) -> Set['Container']:
         muxers = {
             muxer
             for muxer, demuxer in _DEMUXER_MAP.items()
@@ -448,5 +448,5 @@ def calculate_aspect_ratio(resolution: list) -> str:
     return f"{resolution[0] // resolution_gcd}:{resolution[1] // resolution_gcd}"
 
 
-def list_supported_frame_rates() -> List[frame_rate.FrameRate]:
+def list_supported_frame_rates() -> Set[frame_rate.FrameRate]:
     return _frame_rates

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -1,6 +1,6 @@
 import enum
 from math import gcd
-from typing import NamedTuple
+from typing import List, NamedTuple, Union, Set
 
 from . import codecs
 from . import exceptions
@@ -52,7 +52,7 @@ class Container(enum.Enum):
     def from_name(name: str) -> 'Container':
         return Container(name.lower())
 
-    def get_supported_video_codecs(self):
+    def get_supported_video_codecs(self) -> List[str]:
         if self in _EXCLUSIVE_DEMUXERS:
             return _list_supported_video_codecs_for_exclusive_demuxer(self)
 
@@ -61,7 +61,7 @@ class Container(enum.Enum):
 
         return _CONTAINER_SUPPORTED_CODECS[self.value]["videocodecs"]
 
-    def get_supported_audio_codecs(self):
+    def get_supported_audio_codecs(self) -> List[str]:
         if self in _EXCLUSIVE_DEMUXERS:
             return _list_supported_audio_codecs_for_exclusive_demuxer(self)
 
@@ -70,7 +70,7 @@ class Container(enum.Enum):
 
         return _CONTAINER_SUPPORTED_CODECS[self.value]["audiocodecs"]
 
-    def is_supported_video_codec(self, vcodec):
+    def is_supported_video_codec(self, vcodec: Union['codecs.VideoCodec', str]) -> bool:
         if isinstance(vcodec, codecs.VideoCodec):
             return vcodec.value in self.get_supported_video_codecs()
         elif isinstance(vcodec, str):
@@ -78,7 +78,7 @@ class Container(enum.Enum):
 
         assert False, "Invalid type"
 
-    def is_supported_audio_codec(self, acodec):
+    def is_supported_audio_codec(self, acodec: Union['codecs.AudioCodec', str]) -> bool:
         if isinstance(acodec, codecs.AudioCodec):
             return acodec.value in self.get_supported_audio_codecs()
         elif isinstance(acodec, str):
@@ -87,23 +87,23 @@ class Container(enum.Enum):
         assert False, "Invalid type"
 
     @staticmethod
-    def is_supported(vformat):
+    def is_supported(vformat: str) -> bool:
         return vformat in list_supported_formats()
 
     @staticmethod
-    def list_supported_formats(vformat):
+    def list_supported_formats(vformat: str) -> List[str]:
         return list_supported_formats()
 
-    def get_demuxer(self):
+    def get_demuxer(self) -> str:
         if self not in _DEMUXER_MAP:
             return self.value
 
         return _DEMUXER_MAP[self].value
 
-    def is_exclusive_demuxer(self):
+    def is_exclusive_demuxer(self) -> bool:
         return self in _EXCLUSIVE_DEMUXERS
 
-    def get_matching_muxers(self):
+    def get_matching_muxers(self) -> Set[str]:
         muxers = {
             muxer
             for muxer, demuxer in _DEMUXER_MAP.items()
@@ -115,7 +115,7 @@ class Container(enum.Enum):
         else:
             return muxers | {self}
 
-    def get_intermediate_muxer(self):
+    def get_intermediate_muxer(self) -> str:
         if self not in _SAFE_INTERMEDIATE_FORMATS:
             return self.value
 
@@ -381,30 +381,30 @@ assert all(isinstance(x.dividend, int) for x in _frame_rates)
 assert all(isinstance(x.divisor, int) for x in _frame_rates)
 
 
-def list_supported_formats():
+def list_supported_formats() -> List[str]:
     return [c.value for c in Container]
 
 
-def is_supported(vformat):
+def is_supported(vformat: str) -> bool:
     return Container.is_supported(vformat)
 
 
-def get_safe_intermediate_format_for_demuxer(demuxer):
+def get_safe_intermediate_format_for_demuxer(demuxer: str) -> str:
     return Container(demuxer).get_intermediate_muxer()
 
 
-def list_supported_video_codecs(vformat):
+def list_supported_video_codecs(vformat: str) -> List[str]:
     if vformat not in Container._value2member_map_:
         return []
 
     return Container(vformat).get_supported_video_codecs()
 
 
-def is_supported_video_codec(vformat, codec):
+def is_supported_video_codec(vformat: str, codec: str) -> bool:
     return codec in list_supported_video_codecs(vformat)
 
 
-def _list_supported_video_codecs_for_exclusive_demuxer(demuxer: Container):
+def _list_supported_video_codecs_for_exclusive_demuxer(demuxer: Container) -> List[str]:
     assert demuxer in _EXCLUSIVE_DEMUXERS
 
     return list(set(
@@ -414,18 +414,18 @@ def _list_supported_video_codecs_for_exclusive_demuxer(demuxer: Container):
     ))
 
 
-def list_supported_audio_codecs(vformat):
+def list_supported_audio_codecs(vformat: str) -> List[str]:
     if vformat not in Container._value2member_map_:
         return []
 
     return Container(vformat).get_supported_audio_codecs()
 
 
-def is_supported_audio_codec(vformat, codec):
+def is_supported_audio_codec(vformat: str, codec: str) -> bool:
     return codec in list_supported_audio_codecs(vformat)
 
 
-def _list_supported_audio_codecs_for_exclusive_demuxer(demuxer: Container):
+def _list_supported_audio_codecs_for_exclusive_demuxer(demuxer: Container) -> List[str]:
     assert demuxer in _EXCLUSIVE_DEMUXERS
 
     return list(set(
@@ -448,5 +448,5 @@ def calculate_aspect_ratio(resolution: list) -> str:
     return f"{resolution[0] // resolution_gcd}:{resolution[1] // resolution_gcd}"
 
 
-def list_supported_frame_rates():
+def list_supported_frame_rates() -> List[frame_rate.FrameRate]:
     return _frame_rates

--- a/ffmpeg_tools/formats.py
+++ b/ffmpeg_tools/formats.py
@@ -91,7 +91,7 @@ class Container(enum.Enum):
         return vformat in list_supported_formats()
 
     @staticmethod
-    def list_supported_formats(vformat: str) -> List[str]:
+    def list_supported_formats() -> List[str]:
         return list_supported_formats()
 
     def get_demuxer(self) -> str:

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -46,24 +46,6 @@ def _get_dst_audio_codec(dst_params: dict, dst_muxer_info: Optional[Dict[str, An
     return dst_params['audio']['codec']
 
 
-def validate_unsupported_data_streams(metadata: dict, strip_unsupported_data_streams: bool):
-    unsupported_data_streams = commands.find_unsupported_data_streams(metadata)
-
-    if not strip_unsupported_data_streams and len(unsupported_data_streams) != 0:
-        raise exceptions.UnsupportedStream('data', unsupported_data_streams)
-
-    return True
-
-
-def validate_unsupported_subtitle_streams(metadata: dict, strip_unsupported_subtitle_streams: bool):
-    unsupported_subtitle_streams = commands.find_unsupported_subtitle_streams(metadata)
-
-    if not strip_unsupported_subtitle_streams and len(unsupported_subtitle_streams) != 0:
-        raise exceptions.UnsupportedStream('subtitle', unsupported_subtitle_streams)
-
-    return True
-
-
 def validate_transcoding_params(
     dst_params,
     src_metadata,
@@ -210,6 +192,24 @@ def validate_video_stream(stream_metadata, video_format):
         validate_video_codec(video_format=video_format, video_codec=stream_metadata["codec_name"])
     except KeyError:
         raise exceptions.InvalidVideo(message="Video stream without specified codec")
+    return True
+
+
+def validate_unsupported_data_streams(metadata: dict, strip_unsupported_data_streams: bool):
+    unsupported_data_streams = commands.find_unsupported_data_streams(metadata)
+
+    if not strip_unsupported_data_streams and len(unsupported_data_streams) != 0:
+        raise exceptions.UnsupportedStream('data', unsupported_data_streams)
+
+    return True
+
+
+def validate_unsupported_subtitle_streams(metadata: dict, strip_unsupported_subtitle_streams: bool):
+    unsupported_subtitle_streams = commands.find_unsupported_subtitle_streams(metadata)
+
+    if not strip_unsupported_subtitle_streams and len(unsupported_subtitle_streams) != 0:
+        raise exceptions.UnsupportedStream('subtitle', unsupported_subtitle_streams)
+
     return True
 
 

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -46,19 +46,22 @@ def _get_dst_audio_codec(dst_params: dict, dst_muxer_info: Optional[Dict[str, An
     return dst_params['audio']['codec']
 
 
-def validate_data_and_subtitle_streams(
-    metadata,
-    strip_unsupported_data_streams,
-    strip_unsupported_subtitle_streams,
-):
+def validate_unsupported_data_streams(metadata: dict, strip_unsupported_data_streams: bool):
     unsupported_data_streams = commands.find_unsupported_data_streams(metadata)
-    unsupported_subtitle_streams = commands.find_unsupported_subtitle_streams(metadata)
 
     if not strip_unsupported_data_streams and len(unsupported_data_streams) != 0:
         raise exceptions.UnsupportedStream('data', unsupported_data_streams)
 
+    return True
+
+
+def validate_unsupported_subtitle_streams(metadata: dict, strip_unsupported_subtitle_streams: bool):
+    unsupported_subtitle_streams = commands.find_unsupported_subtitle_streams(metadata)
+
     if not strip_unsupported_subtitle_streams and len(unsupported_subtitle_streams) != 0:
         raise exceptions.UnsupportedStream('subtitle', unsupported_subtitle_streams)
+
+    return True
 
 
 def validate_transcoding_params(
@@ -138,9 +141,11 @@ def validate_transcoding_params(
 
     validate_frame_rate(dst_params, src_params.get("frame_rate"))
 
-    validate_data_and_subtitle_streams(
+    validate_unsupported_data_streams(
         src_metadata,
-        strip_unsupported_data_streams,
+        strip_unsupported_data_streams)
+    validate_unsupported_subtitle_streams(
+        src_metadata,
         strip_unsupported_subtitle_streams)
     return True
 

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -258,7 +258,7 @@ def _guess_target_frame_rate_for_special_cases(
 
 def _guess_target_frame_rate(
         src_frame_rate: 'frame_rate.FrameRate',
-        dst_params: Dict[str, Any]) -> str:
+        dst_params: Dict[str, Any]) -> 'frame_rate.FrameRate':
 
     target_frame_rate = _guess_target_frame_rate_for_special_cases(
         src_frame_rate,

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -51,9 +51,9 @@ def validate_data_and_subtitle_streams(
     strip_unsupported_data_streams,
     strip_unsupported_subtitle_streams,
 ):
-    (unsupported_data_streams, unsupported_subtitle_streams) = (
-        commands.get_lists_of_unsupported_stream_numbers(metadata)
-    )
+    unsupported_data_streams = commands.find_unsupported_data_streams(metadata)
+    unsupported_subtitle_streams = commands.find_unsupported_subtitle_streams(metadata)
+
     if not strip_unsupported_data_streams and len(unsupported_data_streams) != 0:
         raise exceptions.UnsupportedStream('data', unsupported_data_streams)
 

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -29,13 +29,13 @@ def validate_video(metadata):
     return True
 
 
-def _get_src_codec(src_params):
+def _get_src_audio_codec(src_params):
     if src_params.get("audio", {}).get("codec") is not None:
         return src_params['audio']['codec']
     return None
 
 
-def _get_dst_codec(dst_params: dict, dst_muxer_info: Optional[Dict[str, Any]]) -> Optional[str]:
+def _get_dst_audio_codec(dst_params: dict, dst_muxer_info: Optional[Dict[str, Any]]) -> Optional[str]:
     assert not formats.Container(dst_params["format"]).is_exclusive_demuxer()
 
     if dst_params.get("audio", {}).get("codec") is None:
@@ -114,13 +114,13 @@ def validate_transcoding_params(
     # Validate audio codec. Audio codec can not be set and ffmpeg should
     # either remain with currently used codec or transcode using default behavior
     # if it is necessary.
-    src_audio_codec = _get_src_codec(src_params)
+    src_audio_codec = _get_src_audio_codec(src_params)
     audio_stream = meta.get_audio_stream(src_metadata)
 
     if src_audio_codec is not None:
         validate_audio_codec(src_params["format"], src_audio_codec)
 
-        dest_audio_codec = _get_dst_codec(dst_params, dst_muxer_info)
+        dest_audio_codec = _get_dst_audio_codec(dst_params, dst_muxer_info)
         if dest_audio_codec is not None:
             validate_audio_codec(dst_params["format"], dest_audio_codec)
             validate_audio_codec_conversion(

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -1,6 +1,5 @@
 import os
-from math import gcd
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from . import meta
 from . import formats

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -1,4 +1,4 @@
-from unittest import TestCase
+from unittest import TestCase, mock
 
 from ffmpeg_tools import codecs
 from ffmpeg_tools import exceptions
@@ -19,13 +19,21 @@ class TestSupportedConversions(TestCase):
     def test_list_audio_conversion_invalid_codec(self):
         assert len(codecs.list_supported_audio_conversions("blabla")) == 0
 
+    @mock.patch.dict('ffmpeg_tools.codecs._VIDEO_SUPPORTED_CONVERSIONS', {"h264": ["h264", "mjpeg", "vp9"]})
     def test_can_convert_correct_video_codec(self):
-        assert "h264" in codecs._VIDEO_SUPPORTED_CONVERSIONS["h264"]
         self.assertTrue(codecs.VideoCodec("h264").can_convert("h264"))
 
+    @mock.patch.dict('ffmpeg_tools.codecs._VIDEO_SUPPORTED_CONVERSIONS', {"h264": ["h264", "mjpeg", "vp9"]})
     def test_can_convert_unsupported_video_codec(self):
-        assert "msmpeg4v2" not in codecs._VIDEO_SUPPORTED_CONVERSIONS["h264"]
         self.assertFalse(codecs.VideoCodec("h264").can_convert("msmpeg4v2"))
+
+    @mock.patch.dict('ffmpeg_tools.codecs._AUDIO_SUPPORTED_CONVERSIONS', {"aac": ["aac", "mp3", "vorbis"]})
+    def test_can_convert_correct_audio_codec(self):
+        self.assertTrue(codecs.AudioCodec("aac").can_convert("aac"))
+
+    @mock.patch.dict('ffmpeg_tools.codecs._AUDIO_SUPPORTED_CONVERSIONS', {"aac": ["aac", "mp3", "vorbis"]})
+    def test_can_convert_unsupported_audio_codec(self):
+        self.assertFalse(codecs.AudioCodec("aac").can_convert("wmapro"))
 
 
 class TestGettingEncoder(TestCase):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -296,13 +296,6 @@ class TestUnsupportedStreamDetection(
         )
         self.assertEqual(stream_number, ([2], [3]))
 
-    def test_function_returns_correct_numbers_streams_metadata(self):
-        stream_number = (
-            commands.find_unsupported_data_streams(self.metadata_with_unsupported_streams),
-            commands.find_unsupported_subtitle_streams(self.metadata_with_unsupported_streams),
-        )
-        self.assertEqual(stream_number, ([2], [3]))
-
 
 class TestQueryMuxerInfo(TestCase):
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -206,38 +206,39 @@ class TestCommands(TestCase):
             )
 
 
-    def test_replace_streams_command_removes_streams_not_in_whitelist(self):
-        with mock.patch('ffmpeg_tools.commands.find_unsupported_data_streams') as _find_unsupported_data_streams, \
-             mock.patch('ffmpeg_tools.commands.find_unsupported_subtitle_streams') as _find_unsupported_subtitle_streams:
-            _find_unsupported_data_streams.return_value = [2]
-            _find_unsupported_subtitle_streams.return_value = [3]
+    @mock.patch('ffmpeg_tools.commands.find_unsupported_data_streams', return_value=[2])
+    @mock.patch('ffmpeg_tools.commands.find_unsupported_subtitle_streams', return_value=[3])
+    def test_replace_streams_command_removes_streams_not_in_whitelist_if_asked_to(
+        self,
+        _mock_find_unsupported_subtitle_streams,
+        _mock_find_unsupported_data_streams,
+    ):
+        command = commands.replace_streams_command(
+            get_absolute_resource_path('ForBiggerBlazes-[codec=h264].mp4'),
+            get_absolute_resource_path('ForBiggerBlazes-[codec=h264][video-only].mkv'),
+            get_absolute_resource_path('ForBiggerBlazes-[codec=h264].mkv'),
+            "v",
+            {},
+            strip_unsupported_data_streams=True,
+            strip_unsupported_subtitle_streams=True
+        )
 
-            command = commands.replace_streams_command(
-                get_absolute_resource_path('ForBiggerBlazes-[codec=h264].mp4'),
-                get_absolute_resource_path('ForBiggerBlazes-[codec=h264][video-only].mkv'),
-                get_absolute_resource_path('ForBiggerBlazes-[codec=h264].mkv'),
-                "v",
-                {},
-                strip_unsupported_data_streams=True,
-                strip_unsupported_subtitle_streams=True
-            )
-
-            expected_command = [
-                "ffmpeg",
-                "-nostdin",
-                "-i", get_absolute_resource_path('ForBiggerBlazes-[codec=h264].mp4'),
-                "-i", get_absolute_resource_path('ForBiggerBlazes-[codec=h264][video-only].mkv'),
-                "-map", "1:v",
-                "-map", "0",
-                "-map", "-0:v",
-                '-map', '-0:2',
-                '-map', '-0:3',
-                "-copy_unknown",
-                "-c:v", "copy",
-                "-c:d", "copy",
-                get_absolute_resource_path('ForBiggerBlazes-[codec=h264].mkv'),
-            ]
-            self.assertEqual(command, expected_command)
+        expected_command = [
+            "ffmpeg",
+            "-nostdin",
+            "-i", get_absolute_resource_path('ForBiggerBlazes-[codec=h264].mp4'),
+            "-i", get_absolute_resource_path('ForBiggerBlazes-[codec=h264][video-only].mkv'),
+            "-map", "1:v",
+            "-map", "0",
+            "-map", "-0:v",
+            '-map', '-0:2',
+            '-map', '-0:3',
+            "-copy_unknown",
+            "-c:v", "copy",
+            "-c:d", "copy",
+            get_absolute_resource_path('ForBiggerBlazes-[codec=h264].mkv'),
+        ]
+        self.assertEqual(command, expected_command)
 
 
     def test_replace_streams_command_does_not_accept_video_parameters(self):
@@ -278,23 +279,18 @@ class MetadataWithSupportedAndUnsupportedStreamsBase(TestCase):
             'some default unsupported name'
 
 
-class TestUnsupportedStreamDetection(
-    MetadataWithSupportedAndUnsupportedStreamsBase
-):
+class TestUnsupportedStreamDetection(MetadataWithSupportedAndUnsupportedStreamsBase):
+    def test_find_unsupported_data_streams_does_not_strip_whitelisted_streams(self):
+        self.assertEqual(commands.find_unsupported_data_streams(self.metadata_without_unsupported_streams), [])
 
-    def test_function_does_not_strip_whitelisted_streams(self):
-        stream_number = (
-            commands.find_unsupported_data_streams(self.metadata_without_unsupported_streams),
-            commands.find_unsupported_subtitle_streams(self.metadata_without_unsupported_streams),
-        )
-        self.assertEqual(stream_number, ([], []))
+    def test_find_unsupported_subtitle_streams_does_not_strip_whitelisted_streams(self):
+        self.assertEqual(commands.find_unsupported_subtitle_streams(self.metadata_without_unsupported_streams), [])
 
-    def test_function_strips_non_whitelisted_streams(self):
-        stream_number = (
-            commands.find_unsupported_data_streams(self.metadata_with_unsupported_streams),
-            commands.find_unsupported_subtitle_streams(self.metadata_with_unsupported_streams),
-        )
-        self.assertEqual(stream_number, ([2], [3]))
+    def test_find_unsupported_data_streams_strips_non_whitelisted_streams(self):
+        self.assertEqual(commands.find_unsupported_data_streams(self.metadata_with_unsupported_streams), [2])
+
+    def test_find_unsupported_subtitle_streams_strips_non_whitelisted_streams(self):
+        self.assertEqual(commands.find_unsupported_subtitle_streams(self.metadata_with_unsupported_streams), [3])
 
 
 class TestQueryMuxerInfo(TestCase):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -205,10 +205,12 @@ class TestCommands(TestCase):
                 {},
             )
 
-    def test_replace_streams_command_removes_streams_not_in_whitelist(self):
-        with mock.patch('ffmpeg_tools.commands.get_lists_of_unsupported_stream_numbers') as _get_lists_of_unsupported_streams_numbers:
 
-            _get_lists_of_unsupported_streams_numbers.return_value = ([2], [3])
+    def test_replace_streams_command_removes_streams_not_in_whitelist(self):
+        with mock.patch('ffmpeg_tools.commands.find_unsupported_data_streams') as _find_unsupported_data_streams, \
+             mock.patch('ffmpeg_tools.commands.find_unsupported_subtitle_streams') as _find_unsupported_subtitle_streams:
+            _find_unsupported_data_streams.return_value = [2]
+            _find_unsupported_subtitle_streams.return_value = [3]
 
             command = commands.replace_streams_command(
                 get_absolute_resource_path('ForBiggerBlazes-[codec=h264].mp4'),
@@ -276,25 +278,29 @@ class MetadataWithSupportedAndUnsupportedStreamsBase(TestCase):
             'some default unsupported name'
 
 
-class TestGetListOfStreamNumbersToSkip(
+class TestUnsupportedStreamDetection(
     MetadataWithSupportedAndUnsupportedStreamsBase
 ):
 
     def test_function_does_not_strip_whitelisted_streams(self):
-        stream_number = commands.get_lists_of_unsupported_stream_numbers(
-            self.metadata_without_unsupported_streams,
+        stream_number = (
+            commands.find_unsupported_data_streams(self.metadata_without_unsupported_streams),
+            commands.find_unsupported_subtitle_streams(self.metadata_without_unsupported_streams),
         )
         self.assertEqual(stream_number, ([], []))
 
     def test_function_strips_non_whitelisted_streams(self):
-        stream_number = commands.get_lists_of_unsupported_stream_numbers(
-            self.metadata_with_unsupported_streams,
+        stream_number = (
+            commands.find_unsupported_data_streams(self.metadata_with_unsupported_streams),
+            commands.find_unsupported_subtitle_streams(self.metadata_with_unsupported_streams),
         )
         self.assertEqual(stream_number, ([2], [3]))
 
     def test_function_returns_correct_numbers_streams_metadata(self):
-        stream_number = commands.get_lists_of_unsupported_stream_numbers(
-            self.metadata_with_unsupported_streams)
+        stream_number = (
+            commands.find_unsupported_data_streams(self.metadata_with_unsupported_streams),
+            commands.find_unsupported_subtitle_streams(self.metadata_with_unsupported_streams),
+        )
         self.assertEqual(stream_number, ([2], [3]))
 
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -4,6 +4,7 @@ from parameterized import parameterized
 
 from ffmpeg_tools import formats
 from ffmpeg_tools import codecs
+from tests.utils import make_parameterized_test_name_generator_for_scalar_values
 
 
 class TestContainer(TestCase):
@@ -147,29 +148,35 @@ class TestSupportedAudioCodecs(object):
 
 class TestAspectRatioCalculations(TestCase):
 
-    @parameterized.expand([
-        ([333, 333], "1:1"),
-        ([333, 666], "1:2"),
-        ([1366, 768], "16:9"),
-        ([1360, 768], "16:9"),
-        ([1920, 1080], "16:9"),
-        ([2560, 1080], "21:9"),
-        ([3440, 1440], "21:9"),
-    ])
+    @parameterized.expand(
+        [
+            ([333, 333], "1:1"),
+            ([333, 666], "1:2"),
+            ([1366, 768], "16:9"),
+            ([1360, 768], "16:9"),
+            ([1920, 1080], "16:9"),
+            ([2560, 1080], "21:9"),
+            ([3440, 1440], "21:9"),
+        ],
+        name_func=make_parameterized_test_name_generator_for_scalar_values(['resolution', 'aspect']),
+    )
     def test_effective_aspect_ratio(self, resolution, expected_aspect_ratio):
         aspect_ratio = formats.get_effective_aspect_ratio(resolution)
         self.assertEqual(aspect_ratio, expected_aspect_ratio)
 
-    @parameterized.expand([
-        ([333, 666], "1:2"),
-        ([1024, 768], "4:3"),
-        ([1920, 1080], "16:9"),
-        ([1280, 1024], "5:4"),
-        ([1360, 768], "85:48"),
-        ([1366, 768], "683:384"),
-        ([2560, 1080], "64:27"),
-        ([3440, 1440], "43:18"),
-    ])
+    @parameterized.expand(
+        [
+            ([333, 666], "1:2"),
+            ([1024, 768], "4:3"),
+            ([1920, 1080], "16:9"),
+            ([1280, 1024], "5:4"),
+            ([1360, 768], "85:48"),
+            ([1366, 768], "683:384"),
+            ([2560, 1080], "64:27"),
+            ([3440, 1440], "43:18"),
+        ],
+        name_func=make_parameterized_test_name_generator_for_scalar_values(['resolution', 'aspect']),
+    )
     def test_calculate_aspect_ratio(self, resolution, expected_aspect_ratio):
         aspect_ratio = formats.calculate_aspect_ratio(resolution)
         self.assertEqual(aspect_ratio, expected_aspect_ratio)

--- a/tests/test_frame_rate.py
+++ b/tests/test_frame_rate.py
@@ -78,7 +78,7 @@ class TestFrameRate(TestCase):
     ])
     def test_from_collection_should_reject_invalid_representations(self, collection):
         with self.assertRaises(ValueError):
-            frame_rate.FrameRate.from_collection(collection),
+            frame_rate.FrameRate.from_collection(collection)
 
     @parameterized.expand([
         ('0', (0, 1)),
@@ -107,7 +107,7 @@ class TestFrameRate(TestCase):
     ])
     def test_from_string_should_reject_invalid_representations(self, string_value):
         with self.assertRaises(ValueError):
-            frame_rate.FrameRate.from_string(string_value),
+            frame_rate.FrameRate.from_string(string_value)
 
     @parameterized.expand([
         ((0, 1), (0, 1)),

--- a/tests/test_frame_rate.py
+++ b/tests/test_frame_rate.py
@@ -1,7 +1,9 @@
 from unittest import TestCase
 
-from ffmpeg_tools import frame_rate
 from parameterized import parameterized
+
+from ffmpeg_tools import frame_rate
+from tests.utils import make_parameterized_test_name_generator_for_scalar_values
 
 
 class TestFrameRate(TestCase):
@@ -10,112 +12,133 @@ class TestFrameRate(TestCase):
         self.assertEqual(frame_rate.FrameRate(10, 5), (10, 5))
         self.assertEqual(frame_rate.FrameRate(10, 6), (10, 6))
 
-    @parameterized.expand([
-        (frame_rate.FrameRate(30), (30, 1)),
-        (frame_rate.FrameRate('30'), ('30', 1)),
-        (0, (0, 1)),
-        (30, (30, 1)),
-        (30.0, (30, 1)),
-        ('30', (30, 1)),
-        ('30/1', (30, 1)),
-        ((30, 1), (30, 1)),
-        ([30, 1], (30, 1)),
-    ])
+    @parameterized.expand(
+        [
+            (frame_rate.FrameRate(30), (30, 1)),
+            (frame_rate.FrameRate('30'), ('30', 1)),
+            (0, (0, 1)),
+            (30, (30, 1)),
+            (30.0, (30, 1)),
+            ('30', (30, 1)),
+            ('30/1', (30, 1)),
+            ((30, 1), (30, 1)),
+            ([30, 1], (30, 1)),
+        ],
+        name_func=make_parameterized_test_name_generator_for_scalar_values(['input', 'output']),
+    )
     def test_decode_should_parse_valid_representations(self, raw_value, expected_tuple):
         decoded_frame_rate = frame_rate.FrameRate.decode(raw_value)
         self.assertIsInstance(decoded_frame_rate, frame_rate.FrameRate)
         self.assertEqual(decoded_frame_rate, frame_rate.FrameRate(*expected_tuple))
 
-    @parameterized.expand([
-        ('',),
-        ('abc',),
-        ('30.0'),
-        ('30.1'),
-        ('30/30/30',),
-        (-30,),
-        (30.1,),
-        ((),),
-        ([],),
-        ((30, 1, 30),),
-        ((30.1, 1),),
-        ({},),
-        (set(),),
-    ])
+    @parameterized.expand(
+        [
+            ('',),
+            ('abc',),
+            ('30.0'),
+            ('30.1'),
+            ('30/30/30',),
+            (-30,),
+            (30.1,),
+            ((),),
+            ([],),
+            ((30, 1, 30),),
+            ((30.1, 1),),
+            ({},),
+            (set(),),
+        ],
+        name_func=make_parameterized_test_name_generator_for_scalar_values(['input']),
+    )
     def test_decode_should_reject_invalid_representations(self, raw_value):
         with self.assertRaises(ValueError):
             frame_rate.FrameRate.decode(raw_value)
 
-    @parameterized.expand([
-        (frame_rate.FrameRate(30), (30, 1)),
-        ((30, 1), (30, 1)),
-        ([30, 1], (30, 1)),
-        ((0,), (0, 1)),
-        ((30,), (30, 1)),
-        ((30, 1), (30, 1)),
-        ((60, 2), (60, 2)),
-        ((62, 4), (62, 4)),
-    ])
+    @parameterized.expand(
+        [
+            (frame_rate.FrameRate(30), (30, 1)),
+            ((30, 1), (30, 1)),
+            ([30, 1], (30, 1)),
+            ((0,), (0, 1)),
+            ((30,), (30, 1)),
+            ((30, 1), (30, 1)),
+            ((60, 2), (60, 2)),
+            ((62, 4), (62, 4)),
+        ],
+        name_func=make_parameterized_test_name_generator_for_scalar_values(['input', 'output']),
+    )
     def test_from_collection_should_parse_valid_representations(self, collection, expected_tuple):
         parsed_frame_rate = frame_rate.FrameRate.from_collection(collection)
         self.assertIsInstance(parsed_frame_rate, frame_rate.FrameRate)
         self.assertEqual(parsed_frame_rate, frame_rate.FrameRate(*expected_tuple))
 
-    @parameterized.expand([
-        ((),),
-        ([],),
-        ((30, 1, 30),),
-        ([30, 1, 30],),
-        ((30.0, 1),),
-        ((30.1, 1),),
-        ((30, '1'),),
-        ((30, 1.5),),
-        ((-1,),),
-        ((10, -10),),
-        ((-10, 10),),
-        ((-10, -10),),
-        ((10, 0),),
-        (frame_rate.FrameRate('30'),),
-    ])
+    @parameterized.expand(
+        [
+            ((),),
+            ([],),
+            ((30, 1, 30),),
+            ([30, 1, 30],),
+            ((30.0, 1),),
+            ((30.1, 1),),
+            ((30, '1'),),
+            ((30, 1.5),),
+            ((-1,),),
+            ((10, -10),),
+            ((-10, 10),),
+            ((-10, -10),),
+            ((10, 0),),
+            (frame_rate.FrameRate('30'),),
+        ],
+        name_func=make_parameterized_test_name_generator_for_scalar_values(['input']),
+    )
     def test_from_collection_should_reject_invalid_representations(self, collection):
         with self.assertRaises(ValueError):
             frame_rate.FrameRate.from_collection(collection)
 
-    @parameterized.expand([
-        ('0', (0, 1)),
-        ('30', (30, 1)),
-        ('30/1', (30, 1)),
-        ('60/2', (60, 2)),
-        ('62/4', (62, 4)),
-    ])
+    @parameterized.expand(
+        [
+            ('0', (0, 1)),
+            ('30', (30, 1)),
+            ('30/1', (30, 1)),
+            ('60/2', (60, 2)),
+            ('62/4', (62, 4)),
+        ],
+        name_func=make_parameterized_test_name_generator_for_scalar_values(['input', 'output']),
+    )
     def test_from_string_should_parse_valid_representations(self, string_value, expected_tuple):
         parsed_frame_rate = frame_rate.FrameRate.from_string(string_value)
         self.assertIsInstance(parsed_frame_rate, frame_rate.FrameRate)
         self.assertEqual(parsed_frame_rate, frame_rate.FrameRate(*expected_tuple))
 
-    @parameterized.expand([
-        ('',),
-        ('abc',),
-        ('29.5',),
-        ('30/1/2',),
-        ('30/',),
-        ('/1',),
-        ('30/1.5',),
-        ('-1',),
-        ('10/-10',),
-        ('-10/10',),
-        ('-10/-10',),
-    ])
+    @parameterized.expand(
+        [
+            ('',),
+            ('abc',),
+            ('29.5',),
+            ('30/1/2',),
+            ('30/',),
+            ('/1',),
+            ('30/1.5',),
+            ('-1',),
+            ('10/-10',),
+            ('-10/10',),
+            ('-10/-10',),
+        ],
+        name_func=make_parameterized_test_name_generator_for_scalar_values(['input']),
+    )
     def test_from_string_should_reject_invalid_representations(self, string_value):
         with self.assertRaises(ValueError):
             frame_rate.FrameRate.from_string(string_value)
 
-    @parameterized.expand([
-        ((0, 1), (0, 1)),
-        ((30, 1), (30, 1)),
-        ((5, 13), (5, 13)),
-        ((60, 2), (30, 1)),
-        ((62, 4), (31, 2)),
-    ])
+    @parameterized.expand(
+        [
+            ((0, 1), (0, 1)),
+            ((30, 1), (30, 1)),
+            ((5, 13), (5, 13)),
+            ((60, 2), (30, 1)),
+            ((62, 4), (31, 2)),
+        ],
+        name_func=make_parameterized_test_name_generator_for_scalar_values(['input', 'output']),
+    )
     def test_normalized_should_return_values_without_common_divisors(self, input_tuple, expected_tuple):
         normalized_frame_rate = frame_rate.FrameRate(*input_tuple).normalized()
         self.assertIsInstance(normalized_frame_rate, frame_rate.FrameRate)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,7 +22,7 @@ class TestIntegration(TestCase):
             'merge': os.path.join(self.tmp_dir, 'merge'),
             'replace': os.path.join(self.tmp_dir, 'replace'),
         }
-        for work_dir_id, work_dir_path in self.work_dirs.items():
+        for _work_dir_id, work_dir_path in self.work_dirs.items():
             os.mkdir(work_dir_path)
 
     def tearDown(self):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,7 +22,7 @@ class TestIntegration(TestCase):
             'merge': os.path.join(self.tmp_dir, 'merge'),
             'replace': os.path.join(self.tmp_dir, 'replace'),
         }
-        for _work_dir_id, work_dir_path in self.work_dirs.items():
+        for _, work_dir_path in self.work_dirs.items():
             os.mkdir(work_dir_path)
 
     def tearDown(self):

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,3 +1,5 @@
+from unittest import TestCase
+
 from ffmpeg_tools import meta
 
 
@@ -97,27 +99,25 @@ example_metadata = {
 
 
 
-class TestMetadata(object):
+class TestMetadata(TestCase):
 
     def test_getting_resolution(self):
-        assert meta.get_resolution(example_metadata) == [1920, 1080]
+        self.assertEqual(meta.get_resolution(example_metadata), [1920, 1080])
 
     def test_get_duration(self):
-        assert meta.get_duration(example_metadata) == 46.120000
+        self.assertEqual(meta.get_duration(example_metadata), 46.120000)
 
     def test_get_video_codec(self):
-        assert meta.get_video_codec(example_metadata) == "vp9"
+        self.assertEqual(meta.get_video_codec(example_metadata), "vp9")
 
     def test_get_audio_codec(self):
-        assert meta.get_audio_codec(example_metadata) == "opus"
+        self.assertEqual(meta.get_audio_codec(example_metadata), "opus")
 
     def test_get_format(self):
-        assert meta.get_format(example_metadata) == "matroska,webm"
+        self.assertEqual(meta.get_format(example_metadata), "matroska,webm")
 
     def test_get_audio_stream(self):
-        assert meta.get_audio_stream(example_metadata) == example_metadata['streams'][1]
+        self.assertEqual(meta.get_audio_stream(example_metadata), example_metadata['streams'][1])
 
     def test_get_metadata_invalid_path(self):
-        assert meta.get_metadata("blabla") == {}
-
-
+        self.assertEqual(meta.get_metadata("blabla"), {})

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+
+from tests.utils import make_parameterized_test_name_generator_for_scalar_values
+
+
+def dummy_function(*_args, **_kwargs):
+    pass
+
+
+class TestTestUtilsMakeParameterizedTestNameGenerator(TestCase):
+    def test_should_return_a_function_that_generates_names(self):
+        generator = make_parameterized_test_name_generator_for_scalar_values(['a', 'b', 'c'])
+        self.assertTrue(callable(generator))
+
+        name = generator(dummy_function, 777, [['x', 'y', 'z']])
+        self.assertEqual(name, "dummy_function_777_a_x_b_y_c_z")
+
+    def test_should_handle_basic_scalar_types(self):
+        generator = make_parameterized_test_name_generator_for_scalar_values(['a', 'b', 'c', 'd', 'e', 'f'])
+        name = generator(dummy_function, 777, [[
+            3,
+            5.0,
+            'stuff',
+            False,
+            True,
+            None,
+        ]])
+
+        self.assertEqual(name, "dummy_function_777_a_3_b_5.0_c_stuff_d_False_e_True_f_None")
+
+    def test_should_not_fail_if_it_gets_a_collection_or_object(self):
+        generator = make_parameterized_test_name_generator_for_scalar_values(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'])
+        name = generator(dummy_function, 777, [[
+            [],
+            [1, 2, 3],
+            (1, 2, 3),
+            {'a': 1},
+            {1, 2, 3},
+            [[], (), {}, set()],
+            [[1, 2], ([([{4: 5}],)],), {}, set()],
+            object(),
+        ]])
+
+        # It should not fail but the name does not have to be sensibly formatted.
+        # We don't want to rely here on its exact structure.
+        self.assertTrue(name.startswith("dummy_function_777_"))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,7 +4,6 @@ from unittest import TestCase
 from parameterized import parameterized
 
 from ffmpeg_tools import codecs
-from ffmpeg_tools import commands
 from ffmpeg_tools import exceptions
 from ffmpeg_tools import validation
 from ffmpeg_tools import formats

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -514,28 +514,28 @@ class TestConversionValidation(TestCase):
             expected_value
         )
 
-    def test_get_dst_codec_returns_audio_codec_from_dst_params_if_present(self):
+    def test_get_dst_audio_codec_returns_audio_codec_from_dst_params_if_present(self):
         params = self.create_params("mp4", [333, 333], "h264", acodec="mp3")
         dst_muxer_info = {'default_audio_codec': "aac"}
-        self.assertEqual(validation._get_dst_codec(params, dst_muxer_info), 'mp3')
+        self.assertEqual(validation._get_dst_audio_codec(params, dst_muxer_info), 'mp3')
 
-    def test_get_dst_codec_returns_default_audio_codec_if_no_dst_audio_params(self):
+    def test_get_dst_audio_codec_returns_default_audio_codec_if_no_dst_audio_params(self):
         params = self.create_params("mp4", [333, 333], "h264", acodec=None)
         assert 'audio' not in params
         dst_muxer_info = {'default_audio_codec': "aac"}
-        self.assertEqual(validation._get_dst_codec(params, dst_muxer_info), 'aac')
+        self.assertEqual(validation._get_dst_audio_codec(params, dst_muxer_info), 'aac')
 
-    def test_get_dst_codec_returns_default_audio_codec_if_no_codec_in_dst_audio_params(self):
+    def test_get_dst_audio_codec_returns_default_audio_codec_if_no_codec_in_dst_audio_params(self):
         params = self.create_params("mp4", [333, 333], "h264", audio_bitrate="192k")
         assert 'codec' not in params['audio']
         dst_muxer_info = {'default_audio_codec': "aac"}
-        self.assertEqual(validation._get_dst_codec(params, dst_muxer_info), 'aac')
+        self.assertEqual(validation._get_dst_audio_codec(params, dst_muxer_info), 'aac')
 
-    def test_get_dst_codec_returns_default_audio_codec_if_codec_missing_from_dst_params(self):
+    def test_get_dst_audio_codec_returns_default_audio_codec_if_codec_missing_from_dst_params(self):
         params = self.create_params("mp4", [333, 333], "h264", acodec="mp3")
         params['audio']['codec'] = None
         dst_muxer_info = {'default_audio_codec': "aac"}
-        self.assertEqual(validation._get_dst_codec(params, dst_muxer_info), 'aac')
+        self.assertEqual(validation._get_dst_audio_codec(params, dst_muxer_info), 'aac')
 
 
 class TestValidateUnsupportedStreams(

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -205,9 +205,9 @@ class TestInputValidation(TestCase):
             })
 
 
-    def validate_video_missing_video_stream(self):
+    def test_validate_video_missing_video_stream(self):
         with self.assertRaises(exceptions.MissingVideoStream):
-            validation.validate_video(filename=self._filename, metadata={
+            validation.validate_video(metadata={
                 "format": self._format_metadata,
                 "streams": [self._audio_stream]
             })

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,7 @@
 import os
 
 
-def get_absolute_resource_path(filename):
+def get_absolute_resource_path(filename: str) -> str:
     return os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         'resources',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,7 @@
 import os
+from typing import List
+
+from ffmpeg_tools import commands
 
 
 def get_absolute_resource_path(filename: str) -> str:
@@ -7,3 +10,15 @@ def get_absolute_resource_path(filename: str) -> str:
         'resources',
         filename
     )
+
+
+def make_parameterized_test_name_generator_for_scalar_values(scalar_names: List[str]):
+    def test_case_name_generator(testcase_func, param_num, param):
+        assert len(param[0]) == len(scalar_names)
+
+        scalar_values = [str(value) for value in param[0]]
+        parameter_names_and_values = '_'.join(commands.flatten_list(zip(scalar_names, scalar_values)))
+
+        return f'{testcase_func.__name__}_{param_num}_{parameter_names_and_values}'
+
+    return test_case_name_generator


### PR DESCRIPTION
### Changes
This is a bunch of changes gathered from my work on task O4 which aren't really a part of its implementation. I put them all here because they don't introduce new functionality and would only make reviewing the actual solution harder. Some of these fix small issues in earlier branches or master. Others are just small improvements, cleanup or refactoring.

I recommend looking at individual commits if you really want to review it. Here's a simplified list of stuff that's changed:
1) Added a function that automatically builds a simple name for all cases tested with `parameterized()`. It's not perfect and names get weird when parameters are collections or complex strings but at least we get something more than a number without having to write a complex custom pattern for each test.
2) Refactored subtitle/data stream stripping functions and validations.
3) Fixed, cleaned up and added more information in the docstring for the `replace` command.
4) Cleaned up `.gitignore` and ignored `.mypy-cache`.
5) Added `can_convert()` for audio codecs which should have been implemented along with the one for video.
6) Rewritten, cleaned up and improved some tests.
    - Rewritten some bad tests for corner cases.
    - There were duplicate tests that were doing exactly the same thing.
    - I found one test for stream validation that was broken and not being running at all due to missing `test_` prefix.
    - I started using `mock.patch()` and `mock.patch.dict()` more to make unit tests more self-contained. This way we won't have to update the tests on every change to the dicts with codec/conversion definitions - only when the functionality itself changes. For example some tests rely on the fact that a specific codec/format/conversion isn't supported and making it supported can break those tests - sometimes even silently in such away that they pass but no longer test what they're supposed to.

        We'll also be able to tests situations that can't happen now but could if we changed the definitions (e.g. testing what happens when something is unsupported when all we have is currently marked as supported).

        This is only in several places right now but I'm using it more heavily in subsequent branches.
7) Tiny bugs in `Container`:
    - `list_supported_formats()` had a useless and unused `format` argument.
    - `is_supported_xxx_codec()` methods were silently ignoring unsupported types instead doing something to let you know that they don't support what you have given them.
8) Added lots of type annotations and fixed several incorrect ones.
9) Removed unused imports, stray commas, marked unused variables with `_`.

### API compatibility
Only refactoring and fixes. Zero changes in the API.

### Dependencies
This pull request is based on #24 and refactors code introduced in all the branches below so it can't be easily rebased directly on `master`.

**NOTE**: I have set the base branch of this pull request to `absolute-resource-paths-and-a-little-cleanup-in-tests` (#24). Please remember to change the base branch back to `master` before you merge.