### PR TITLE
[P6b] Audio sample rate validation

### DIFF
--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -765,6 +765,9 @@ def query_encoder_info(encoder):
             f"Expected exactly one.")
 
     if len(matches) == 1:
-        return {
-            'sample_rates': {int(sr) for sr in matches[0].strip().split(" ")},
-        }
+        rate_strings = {s for s in matches[0].strip().split(" ") if s != ''}
+        try:
+            return {'sample_rates': {int(s) for s in rate_strings}}
+        except (ValueError, TypeError):
+            raise exceptions.InvalidSampleRateInfo(f"Failed to parse sample rates reported by ffmpeg as integers.")
+

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -682,7 +682,7 @@ def _parse_default_audio_codec_out_of_muxer_info(muxer_info: str) -> List[str]:
     return re.findall(
         r"""
         ^\s*                        # Leading whitespace
-        Default\ ?audio\ ?codec:\s* # Label
+        Default\ ?audio\ ?codec:\ * # Label
         (.*[^\s.])\s*               # Codec name
         \.?                         # Optional dot at the end of the line
         \s*$                        # Trailing whitespace
@@ -744,7 +744,7 @@ def _parse_supported_sample_rates_out_of_encoder_info(codec_info):
     return re.findall(
         r"""
         ^\s*                           # Leading whitespace
-        Supported\ ?sample\ ?rates:\s* # Label
+        Supported\ ?sample\ ?rates:\ * # Label
         (.*[^\s])\s*$                  # Sample rate list
         """,
         codec_info,

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -745,9 +745,7 @@ def _parse_supported_sample_rates_out_of_encoder_info(codec_info):
         r"""
         ^\s*                           # Leading whitespace
         Supported\ ?sample\ ?rates:\s* # Label
-        (.*[^\s.])\s*                  # Sample rate list
-        \.?                            # Optional dot at the end of the line
-        \s*$                           # Trailing whitespace
+        (.*[^\s])\s*$                  # Sample rate list
         """,
         codec_info,
         re.X | re.MULTILINE

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -768,9 +768,9 @@ def query_encoder_info(encoder):
             f"Expected exactly one.")
 
     if len(matches) == 1:
-        rate_strings = {s for s in matches[0].strip().split(" ") if s != ''}
+        rate_strings = [s for s in matches[0].strip().split(" ") if s != '']
         try:
-            return {'sample_rates': {int(s) for s in rate_strings}}
+            return {'sample_rates': [int(s) for s in rate_strings]}
         except (ValueError, TypeError):
             raise exceptions.InvalidSampleRateInfo(f"Failed to parse sample rates reported by ffmpeg as integers.")
 

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+import sys
 import json
 from typing import Any, Dict, List
 
@@ -757,6 +758,8 @@ def query_encoder_info(encoder):
     matches = _parse_supported_sample_rates_out_of_encoder_info(ffmpeg_output)
 
     if len(matches) == 0:
+        # We won't be able to validate target sample rate without this information
+        print(f"WARNING: ffmpeg does not provide information about sample rates for encoder '{encoder}'.", file=sys.stderr)
         return {}
 
     if len(matches) >= 2:

--- a/ffmpeg_tools/commands.py
+++ b/ffmpeg_tools/commands.py
@@ -683,7 +683,7 @@ def _parse_default_audio_codec_out_of_muxer_info(muxer_info: str) -> List[str]:
         r"""
         ^\s*                        # Leading whitespace
         Default\ ?audio\ ?codec:\ * # Label
-        (.*[^\s.])\s*               # Codec name
+        (.*[^\s.]|)\s*              # Codec name
         \.?                         # Optional dot at the end of the line
         \s*$                        # Trailing whitespace
         """,
@@ -745,7 +745,7 @@ def _parse_supported_sample_rates_out_of_encoder_info(codec_info):
         r"""
         ^\s*                           # Leading whitespace
         Supported\ ?sample\ ?rates:\ * # Label
-        (.*[^\s])\s*$                  # Sample rate list
+        (.*[^\s]|)\s*$                 # Sample rate list
         """,
         codec_info,
         re.X | re.MULTILINE

--- a/ffmpeg_tools/exceptions.py
+++ b/ffmpeg_tools/exceptions.py
@@ -97,6 +97,12 @@ class UnsupportedStream(InvalidVideo):
                          .format(stream_type, index))
 
 
+class UnsupportedSampleRate(InvalidVideo):
+    def __init__(self, sample_rate, codec):
+        super().__init__(message="Codec {} does not the support sample rate {}."
+                         .format(codec, sample_rate))
+
+
 class UnsupportedAudioChannelLayout(InvalidVideo):
     def __init__(self, audio_channels):
         super().__init__(

--- a/ffmpeg_tools/exceptions.py
+++ b/ffmpeg_tools/exceptions.py
@@ -2,6 +2,10 @@ class NoMatchingEncoder(Exception):
     pass
 
 
+class InvalidSampleRateInfo(Exception):
+    pass
+
+
 class CommandFailed(Exception):
     def __init__(self, command, error_code):
         super().__init__()

--- a/ffmpeg_tools/meta.py
+++ b/ffmpeg_tools/meta.py
@@ -28,6 +28,14 @@ def get_frame_rate(metadata):
     return None
 
 
+def get_sample_rates(metadata):
+    return [
+        stream["sample_rate"]
+        for stream in metadata["streams"]
+        if stream["codec_type"] == "audio"
+    ]
+
+
 def get_duration(metadata, stream=0):
     return float(metadata["format"]["duration"])
 

--- a/ffmpeg_tools/meta.py
+++ b/ffmpeg_tools/meta.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from . import commands
 from . import exceptions
@@ -38,15 +38,18 @@ def _try_int(value: Any) -> Any:
     return value
 
 
-def get_sample_rates(metadata):
+def get_sample_rates(metadata: Dict[str, Any]) -> List[Union[str, int]]:
     return [
         # Sample rates should always be integers but just in case we get a weird
         # file for which ffprobe reports garbage, we'll return raw values if
         # they cannot be converted. That's more useful that just refusing to work
         # and it's the job of validations to reject these values if they're invalid.
-        _try_int(stream.get("sample_rate"))
-        for stream in metadata["streams"]
-        if stream["codec_type"] == "audio"
+        _try_int(s)
+        for s in get_attribute_from_all_streams(
+            metadata,
+            'sample_rate',
+            'audio'
+        )
     ]
 
 

--- a/ffmpeg_tools/meta.py
+++ b/ffmpeg_tools/meta.py
@@ -28,9 +28,23 @@ def get_frame_rate(metadata):
     return None
 
 
+def _try_int(value: Any) -> Any:
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            pass
+
+    return value
+
+
 def get_sample_rates(metadata):
     return [
-        stream.get("sample_rate")
+        # Sample rates should always be integers but just in case we get a weird
+        # file for which ffprobe reports garbage, we'll return raw values if
+        # they cannot be converted. That's more useful that just refusing to work
+        # and it's the job of validations to reject these values if they're invalid.
+        _try_int(stream.get("sample_rate"))
         for stream in metadata["streams"]
         if stream["codec_type"] == "audio"
     ]

--- a/ffmpeg_tools/meta.py
+++ b/ffmpeg_tools/meta.py
@@ -30,7 +30,7 @@ def get_frame_rate(metadata):
 
 def get_sample_rates(metadata):
     return [
-        stream["sample_rate"]
+        stream.get("sample_rate")
         for stream in metadata["streams"]
         if stream["codec_type"] == "audio"
     ]

--- a/ffmpeg_tools/meta.py
+++ b/ffmpeg_tools/meta.py
@@ -94,15 +94,27 @@ def get_attribute_from_all_streams(
     ]
 
 
-def create_params(vformat, resolution, vcodec, acodec=None,
-                  frame_rate=None, video_bitrate=None,
-                  audio_bitrate=None, scaling_algorithm=None):
-    args = dict()
+def create_params(
+    vformat,
+    resolution,
+    vcodec,
+    acodec=None,
+    frame_rate=None,
+    video_bitrate=None,
+    audio_bitrate=None,
+    scaling_algorithm=None,
+    sample_rates=None
+):
+
+    args = {}
+
+    if sample_rates is None:
+        sample_rates = []
 
     args["format"] = vformat
 
     # Video parameters
-    args["video"] = dict()
+    args["video"] = {}
 
     args["resolution"] = resolution
     args["video"]["codec"] = vcodec
@@ -117,11 +129,14 @@ def create_params(vformat, resolution, vcodec, acodec=None,
         args["frame_rate"] = frame_rate
 
     # Audio parameters
-    if acodec or audio_bitrate:
+    if acodec or audio_bitrate or sample_rates:
         args["audio"] = {}
 
     if acodec:
         args["audio"]["codec"] = acodec
+
+    if sample_rates:
+        args["audio"]["sample_rates"] = sample_rates
 
     if audio_bitrate:
         args["audio"]["bitrate"] = audio_bitrate

--- a/ffmpeg_tools/meta.py
+++ b/ffmpeg_tools/meta.py
@@ -120,13 +120,9 @@ def create_params(
     video_bitrate=None,
     audio_bitrate=None,
     scaling_algorithm=None,
-    sample_rates=None
 ):
 
     args = {}
-
-    if sample_rates is None:
-        sample_rates = []
 
     args["format"] = vformat
 
@@ -146,14 +142,11 @@ def create_params(
         args["frame_rate"] = frame_rate
 
     # Audio parameters
-    if acodec or audio_bitrate or sample_rates:
+    if acodec or audio_bitrate:
         args["audio"] = {}
 
     if acodec:
         args["audio"]["codec"] = acodec
-
-    if sample_rates:
-        args["audio"]["sample_rates"] = sample_rates
 
     if audio_bitrate:
         args["audio"]["bitrate"] = audio_bitrate

--- a/ffmpeg_tools/utils.py
+++ b/ffmpeg_tools/utils.py
@@ -1,0 +1,37 @@
+from typing import Optional, Set, Tuple, Union
+
+
+Subrange = Union[int, Tuple[Optional[int], Optional[int]]]
+
+
+class SparseRange:
+    def __init__(self, subranges: Set[Subrange]):
+        assert all(
+            isinstance(subrange, int)
+            or subrange[0] is None
+            or subrange[1] is None
+            or subrange[0] <= subrange[1]
+            for subrange in subranges
+        )
+
+        self._points = {subrange for subrange in subranges if not isinstance(subrange, tuple)}
+        self._ranges = {subrange for subrange in subranges if isinstance(subrange, tuple)}
+
+    def contains(self, value: int) -> bool:
+        if value in self._points:
+            return True
+
+        for range in self._ranges:
+            if range[0] == range[1] == None:
+                return True
+
+            finite_range = (
+                range[0] if range[0] is not None else min(value, range[1]),
+                range[1] if range[1] is not None else max(value, range[0]),
+            )
+            assert finite_range[0] <= finite_range[1]
+
+            if finite_range[0] <= value <= finite_range[1]:
+                return True
+
+        return False

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -326,7 +326,7 @@ def validate_audio_sample_rate(dest_audio_codec: str, source_sample_rates: Optio
         return
 
     dest_encoder_info = commands.query_encoder_info(dest_audio_codec)
-    unsupported_sample_rates = set(int(sr) for sr in source_sample_rates) - set(dest_encoder_info.get('sample_rates'))
+    unsupported_sample_rates = set(source_sample_rates) - set(dest_encoder_info.get('sample_rates'))
     if len(unsupported_sample_rates) > 0:
         raise exceptions.UnsupportedSampleRate(unsupported_sample_rates, dest_audio_codec)
 

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -50,7 +50,7 @@ def validate_transcoding_params(
     dst_params,
     src_metadata,
     dst_muxer_info = None,
-    dst_audio_encoder_info = {},
+    dst_audio_encoder_info = None,
     strip_unsupported_data_streams=False,
     strip_unsupported_subtitle_streams=False,
 ):
@@ -318,10 +318,16 @@ def validate_frame_rate(
 def validate_audio_sample_rates(
         src_metadata: Dict[str, Any],
         dest_audio_codec: str,
-        dst_audio_encoder_info: Dict[str, Any]) -> bool:
+        dst_audio_encoder_info: Optional[Dict[str, Any]]) -> bool:
 
     assert dest_audio_codec in codecs.AudioCodec._value2member_map_
     assert codecs.AudioCodec(dest_audio_codec).get_encoder() is not None
+
+    if dst_audio_encoder_info is None:
+        # If the user has decided not to provide encoder info, there's nothing
+        # we can do. We can't be sure that the target sample rate is supported
+        # but we want this info to be optional so we can't just reject the video.
+        return True
 
     if 'sample_rates' not in dst_audio_encoder_info:
         # NOTE: `ffmpeg -h` unfortunately does not provide sample rates in all

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -503,7 +503,7 @@ class TestQueryMuxerInfo(TestCase):
             self.assertIsInstance(muxer_info, dict)
             self.assertNotIn('default_audio_codec', muxer_info)
 
-    def test_default_audio_codec_field_should_be_omitted_if_multiple_matches_found_in_ffmpeg_output(self):
+    def test_should_raise_if_multiple_matches_found_in_ffmpeg_output(self):
         sample_ffmpeg_output = (
             'Muxer 3g2 [3GP2 (3GPP2 file format)]:\n'
             '   Common extensions: 3g2.\n'

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -613,8 +613,7 @@ class TestQueryEncoderInfo(TestCase):
     @parameterized.expand([
         ('Supported sample rates: 44100 48000 32000 22050 24000 16000 11025 12000 8000\n', ['44100 48000 32000 22050 24000 16000 11025 12000 8000']),
         ('Supported sample rates: 44100 48000 \n', ['44100 48000']),
-        ('Supported sample rates: 44100 48000. \n', ['44100 48000']),
-        ('  Supported sample rates: 44100 48000. \n', ['44100 48000']),
+        ('  Supported sample rates: 44100 48000 \n', ['44100 48000']),
         ('Supported sample rates: 44100 48000. something after \n', ['44100 48000. something after']),
         ('Supported sample rates: 44100 48000 Supported sample rates: 16000 24000 \n', ['44100 48000 Supported sample rates: 16000 24000']),
     ])

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -503,6 +503,18 @@ class TestQueryMuxerInfo(TestCase):
             self.assertIsInstance(muxer_info, dict)
             self.assertNotIn('default_audio_codec', muxer_info)
 
+    def test_default_audio_codec_field_should_not_be_omitted_if_codec_name_is_an_empty_string(self):
+        sample_ffmpeg_output = (
+            'Muxer 3g2 [3GP2 (3GPP2 file format)]:\n'
+            '   Common extensions: 3g2.\n'
+            '   Default audio codec:\n'
+        )
+
+        with mock.patch.object(commands, 'exec_cmd_to_string', return_value=sample_ffmpeg_output):
+            muxer_info = commands.query_muxer_info(formats.Container.c_3G2)
+            self.assertIsInstance(muxer_info, dict)
+            self.assertEqual(muxer_info['default_audio_codec'], '')
+
     def test_should_raise_if_multiple_matches_found_in_ffmpeg_output(self):
         sample_ffmpeg_output = (
             'Muxer 3g2 [3GP2 (3GPP2 file format)]:\n'
@@ -543,6 +555,8 @@ class TestQueryMuxerInfo(TestCase):
         ('Default audio codec: amr_nb_\n', ['amr_nb_']),
         ('Default audio codec: amr_nb. Default audio codec: mp2 \n', ['amr_nb. Default audio codec: mp2']),
         ('    Default audio codec: amr_nb-x!\n', ['amr_nb-x!']),
+        ('Default audio codec:\n', ['']),
+        ('Default audio codec: \n', ['']),
     ])
     def test_default_audio_encoder_parsing_corner_cases(
         self,
@@ -616,6 +630,8 @@ class TestQueryEncoderInfo(TestCase):
         ('  Supported sample rates: 44100 48000 \n', ['44100 48000']),
         ('Supported sample rates: 44100 48000. something after \n', ['44100 48000. something after']),
         ('Supported sample rates: 44100 48000 Supported sample rates: 16000 24000 \n', ['44100 48000 Supported sample rates: 16000 24000']),
+        ('Supported sample rates:\n', ['']),
+        ('Supported sample rates: \n', ['']),
     ])
     def test_sample_rate_parsing_corner_cases(self, input_line, expected_result):
         sample_ffmpeg_output = (

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -582,7 +582,7 @@ class TestQueryEncoderInfo(TestCase):
             'Supported sample formats: s32p fltp s16p\n'
             'Supported channel layouts: mono stereo\n'
         )
-        expected_encoder_info = {'sample_rates': {44100, 48000, 32000, 22050, 24000, 16000, 11025, 12000, 8000}}
+        expected_encoder_info = {'sample_rates': [44100, 48000, 32000, 22050, 24000, 16000, 11025, 12000, 8000]}
 
         with mock.patch.object(commands, 'exec_cmd_to_string', return_value=sample_ffmpeg_output):
             encoder_info = commands.query_encoder_info('mp3')
@@ -644,11 +644,11 @@ class TestQueryEncoderInfo(TestCase):
 
     @parameterized.expand(
         [
-            ('', set()),
-            ('44100 48000', {44100, 48000}),
-            ('44100 -48000 0', {44100, -48000, 0}),
-            ('44100 44100 44100', {44100}),
-            ('4410044100441004410044100441004410044100', {4410044100441004410044100441004410044100}),
+            ('', []),
+            ('44100 48000', [44100, 48000]),
+            ('44100 -48000 0', [44100, -48000, 0]),
+            ('44100 44100 44100', [44100, 44100, 44100]),
+            ('4410044100441004410044100441004410044100', [4410044100441004410044100441004410044100]),
         ],
         name_func=make_parameterized_test_name_generator_for_scalar_values(['input', 'output']),
     )

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -113,6 +113,31 @@ class TestMetadata(TestCase):
     def test_get_audio_codec(self):
         self.assertEqual(meta.get_audio_codec(example_metadata), "opus")
 
+    def test_get_sample_rates(self):
+        metadata = {'streams': [
+            {"codec_type": "video", 'sample_rate': 44100},
+            {"codec_type": "audio", 'sample_rate': 48000},
+            {"codec_type": "audio", 'sample_rate': 8000},
+            {"codec_type": "audio", 'sample_rate': 8000},
+            {"codec_type": "data", 'sample_rate': 555},
+            {"codec_type": "whatever", 'sample_rate': 666},
+            {"codec_type": "", 'sample_rate': 777},
+            {"codec_type": None, 'sample_rate': 888},
+            {'sample_rate': 999},
+            {"codec_type": "audio", 'sample_rate': '96000'},
+            {"codec_type": "audio", 'sample_rate': 32000.0},
+            {"codec_type": "audio", 'sample_rate': '16000.0'},
+            {"codec_type": "audio", 'sample_rate': 10.5},
+            {"codec_type": "audio", 'sample_rate': {}},
+            {"codec_type": "audio", 'sample_rate': [1, 2, 3]},
+            {"codec_type": "audio", 'sample_rate': None},
+            {"codec_type": "audio"},
+            {},
+        ]}
+        self.assertCountEqual(meta.get_sample_rates(metadata), [
+            48000, 8000, 8000, 96000, 32000.0, '16000.0', 10.5, {}, [1, 2, 3], None, None,
+        ])
+
     def test_get_format(self):
         self.assertEqual(meta.get_format(example_metadata), "matroska,webm")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+from unittest import TestCase
+from parameterized import parameterized
+
+from ffmpeg_tools import utils
+from tests.utils import make_parameterized_test_name_generator_for_scalar_values
+
+
+class TestSparseRange(TestCase):
+    @parameterized.expand(
+        [
+            (set(), 0, False),
+            ({1, 2, 3}, 1, True),
+            ({1, 2, 3}, 3, True),
+            ({1, 2, 3}, 5, False),
+            ({-5, 0, 5}, -5, True),
+            ({-5, 0, 5}, -4, False),
+            ({(1, 5)}, 0, False),
+            ({(1, 5)}, 1, True),
+            ({(1, 5)}, 3, True),
+            ({(1, 5)}, 5, True),
+            ({(1, 5)}, 6, False),
+            ({(1, 5), (10, 15)}, 3, True),
+            ({(1, 5), (10, 15)}, 7, False),
+            ({(1, 5), (10, 15)}, 12, True),
+            ({1, (10, 15)}, 1, True),
+            ({1, (10, 15)}, 3, False),
+            ({1, (10, 15)}, 12, True),
+            ({(10, None)}, 12, True),
+            ({(10, None)}, 12000, True),
+            ({(10, None)}, 9, False),
+            ({(None, 10)}, 11, False),
+            ({(None, 10)}, 9, True),
+            ({(None, 10)}, -12000, True),
+            ({(None, None)}, -12000, True),
+            ({(None, None)}, 0, True),
+            ({(None, None)}, 12000, True),
+            ({(10, None), 12}, 10, True),
+            ({(10, None), 12}, 11, True),
+            ({(10, None), 12}, 12, True),
+            ({1, 2, 3, (1, 3)}, 0, False),
+            ({1, 2, 3, (1, 3)}, 1, True),
+            ({1, 2, 3, (1, 3)}, 2, True),
+            ({1, 2, 3, (1, 3)}, 3, True),
+            ({1, 2, 3, (1, 3)}, 4, False),
+        ],
+        name_func=make_parameterized_test_name_generator_for_scalar_values(['subrange', 'value', 'result']),
+    )
+    def test_contains(self, subranges, value, expected_result):
+        self.assertEqual(utils.SparseRange(subranges).contains(value), expected_result)
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -281,8 +281,9 @@ class TestConversionValidation(TestCase):
             ('amr_nb', 8000),
         ])
         dst_params = self.create_params("mp4", [640, 480], "h264", "mp3", 60)
+        dst_audio_encoder_info = {'sample_rates': [48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000]}
 
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}, dst_audio_encoder_info))
 
 
     def test_default_target_audio_codec_supports_source_sample_rate(self):
@@ -294,8 +295,9 @@ class TestConversionValidation(TestCase):
         ])
         dst_params = self.create_params("mp4", [640, 480], "h264")
         dst_muxer_info = {'default_audio_codec': "mp3"}
+        dst_audio_encoder_info = {'sample_rates': [48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000]}
 
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info, dst_audio_encoder_info))
 
 
     def test_target_audio_codec_does_not_support_source_sample_rate(self):
@@ -306,9 +308,10 @@ class TestConversionValidation(TestCase):
             ('amr_nb', 8000),
         ])
         dst_params = self.create_params("mp4", [640, 480], "h264", "mp3", 60)
+        dst_audio_encoder_info = {'sample_rates': [48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000]}
 
         with self.assertRaises(exceptions.UnsupportedSampleRate):
-            validation.validate_transcoding_params(dst_params, metadata, {})
+            validation.validate_transcoding_params(dst_params, metadata, {}, dst_audio_encoder_info)
 
 
     def test_default_target_audio_codec_does_not_support_source_sample_rate(self):
@@ -320,16 +323,17 @@ class TestConversionValidation(TestCase):
         ])
         dst_params = self.create_params("mp4", [640, 480], "h264")
         dst_muxer_info = {'default_audio_codec': "mp3"}
+        dst_audio_encoder_info = {'sample_rates': [48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000]}
 
         with self.assertRaises(exceptions.UnsupportedSampleRate):
-            self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info))
+            self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info, dst_audio_encoder_info))
 
 
     def test_container_change(self):
         metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3", 60)
         dst_params = self.create_params("mov", [1920, 1080], "h264", "mp3", 60)
 
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}, {}))
 
 
     def test_container_change_when_target_is_an_exclusive_demuxer(self):
@@ -338,14 +342,14 @@ class TestConversionValidation(TestCase):
         metadata = self.modify_metadata_with_passed_values("matroska", [1920, 1080], "h264", "mp3")
         dst_params = self.create_params(formats.Container.c_MATROSKA_WEBM_DEMUXER.value, [1920, 1080], "h264")
         with self.assertRaises(exceptions.UnsupportedTargetVideoFormat):
-            validation.validate_transcoding_params(dst_params, metadata, {})
+            validation.validate_transcoding_params(dst_params, metadata, {}, {})
 
 
     def test_video_codec_change(self):
         metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3", 60)
         dst_params = self.create_params("mp4", [1920, 1080], "h265", "mp3", 60)
 
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}, {}))
 
 
     def test_invalid_audio_codec_change(self):
@@ -354,14 +358,14 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "wmapro", 60)
 
         with self.assertRaises(exceptions.UnsupportedAudioCodec):
-            validation.validate_transcoding_params(dst_params, metadata, {})
+            validation.validate_transcoding_params(dst_params, metadata, {}, {})
 
 
     def test_resolution_change(self):
         metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3", 60)
         dst_params = self.create_params("mp4", [640, 360], "h264", "mp3", 60)
 
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}, {}))
 
 
     def test_no_audio_codec(self):
@@ -370,7 +374,7 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [640, 360], "h264", None, 60)
         dst_muxer_info = {'default_audio_codec': "aac"}
 
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info, {}))
 
 
     def test_invalid_src_video_codec(self):
@@ -378,7 +382,7 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "mp3", 60)
 
         with self.assertRaises(exceptions.UnsupportedVideoCodec):
-            validation.validate_transcoding_params(dst_params, metadata, {})
+            validation.validate_transcoding_params(dst_params, metadata, {}, {})
 
 
     def test_invalid_dst_video_codec(self):
@@ -386,7 +390,7 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [1920, 1080], "avi", "mp3", 60)
 
         with self.assertRaises(exceptions.UnsupportedVideoCodec):
-            validation.validate_transcoding_params(dst_params, metadata, {})
+            validation.validate_transcoding_params(dst_params, metadata, {}, {})
 
 
     def test_invalid_resolution_change(self):
@@ -394,7 +398,7 @@ class TestConversionValidation(TestCase):
         dst_params = self.create_params("mp4", [1280, 1024], "h264", "mp3", 60)
 
         with self.assertRaises(exceptions.InvalidResolution):
-            validation.validate_transcoding_params(dst_params, metadata, {})
+            validation.validate_transcoding_params(dst_params, metadata, {}, {})
 
     @parameterized.expand(
         [
@@ -415,7 +419,7 @@ class TestConversionValidation(TestCase):
         metadata = self.modify_metadata_with_passed_values("mp4", src_resolution, "h264", "mp3", 60)
         dst_params = self.create_params("mp4", target_resolution, "h264", "mp3", 60)
 
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}, {}))
 
     def test_validate_audio_codec_conversion_should_reject_videos_with_more_than_two_channels_if_audio_must_be_transcoded(self):
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "mp3", 60)
@@ -424,7 +428,7 @@ class TestConversionValidation(TestCase):
         assert unsupported_metadata['streams'][1]['codec_name'] != "mp3"
 
         with self.assertRaises(exceptions.UnsupportedAudioChannelLayout):
-            validation.validate_transcoding_params(dst_params, unsupported_metadata, {})
+            validation.validate_transcoding_params(dst_params, unsupported_metadata, {}, {})
 
     def test_validate_audio_codec_conversion_should_not_reject_videos_with_two_or_less_channels_even_if_audio_must_be_transcoded(self):
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "mp3", 60)
@@ -432,7 +436,7 @@ class TestConversionValidation(TestCase):
         unsupported_metadata['streams'][1]['channels'] = 1
         assert unsupported_metadata['streams'][1]['codec_name'] != "mp3"
 
-        self.assertTrue(validation.validate_transcoding_params(dst_params, unsupported_metadata, {}))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, unsupported_metadata, {}, {}))
 
     def test_validate_audio_codec_conversion_should_accept_videos_with_more_than_two_channels_if_audio_does_not_have_to_be_transcoded(self):
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "aac", 60)
@@ -440,27 +444,27 @@ class TestConversionValidation(TestCase):
         unsupported_metadata['streams'][1]['channels'] = validation._MAX_SUPPORTED_AUDIO_CHANNELS + 1
         assert unsupported_metadata['streams'][1]['codec_name'] == "aac"
 
-        self.assertTrue(validation.validate_transcoding_params(dst_params, unsupported_metadata, {}))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, unsupported_metadata, {}, {}))
 
     def test_default_audio_codec_should_be_validated_if_dst_audio_codec_missing(self):
         metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3", frame_rate=60)
         dst_params = self.create_params("mp4", [1920, 1080], "h264", acodec=None)
         dst_muxer_info = {'default_audio_codec': "unsupported_audio_codec"}
         with self.assertRaises(exceptions.UnsupportedAudioCodec):
-            validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info)
+            validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info, {})
 
     def test_default_audio_codec_should_be_ignored_if_dst_audio_codec_present(self):
         metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3", frame_rate=60)
         dst_params = self.create_params("mp4", [1920, 1080], "h264", acodec="aac")
         dst_muxer_info = {'default_audio_codec': "unsupported_audio_codec"}
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info, {}))
 
     def test_validation_should_fail_if_ffmpeg_reports_no_default_audio_codec_for_a_format(self):
         metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "aac", frame_rate=60)
         dst_params = self.create_params("mpeg", [1920, 1080], "mpeg1video")
         dst_muxer_info = {}
         with self.assertRaises(exceptions.UnsupportedAudioCodecConversion):
-            validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info)
+            validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info, {})
 
     def test_validation_should_not_fail_even_if_audio_codec_is_not_specified_and_muxer_info_is_not_available(self):
         metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "aac", frame_rate=60)
@@ -484,7 +488,7 @@ class TestConversionValidation(TestCase):
 
         metadata = self.modify_metadata_with_passed_values("mov", [1920, 1080], codecs.VideoCodec.MPEG_1.value, "aac", frame_rate=src_frame_rate)
         dst_params = self.create_params("mov", [1920, 1080], codecs.VideoCodec.MPEG_1.value, "aac", frame_rate=None)
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}, {}))
 
     @parameterized.expand(
         [
@@ -503,7 +507,7 @@ class TestConversionValidation(TestCase):
         metadata = self.modify_metadata_with_passed_values("mov", [1920, 1080], codecs.VideoCodec.MPEG_1.value, "aac", frame_rate=30)
         dst_params = self.create_params("mov", [1920, 1080], codecs.VideoCodec.MPEG_1.value, "aac", frame_rate=dst_frame_rate)
         with self.assertRaises(exceptions.InvalidFrameRate):
-            validation.validate_transcoding_params(dst_params, metadata, {})
+            validation.validate_transcoding_params(dst_params, metadata, {}, {})
 
     def test_source_frame_rate_when_substituted_is_validated_as_the_resulting_value_when_implicitly_used_as_target_frame_rate(self):
         assert frame_rate.FrameRate(25, 2) in codecs.FRAME_RATE_SUBSTITUTIONS.get(codecs.VideoCodec.MPEG_2.value, {})
@@ -512,7 +516,7 @@ class TestConversionValidation(TestCase):
 
         metadata = self.modify_metadata_with_passed_values("mov", [1920, 1080], "mpeg2video", "aac", frame_rate='25/2')
         dst_params = self.create_params("mov", [1920, 1080], "mpeg2video", "aac", frame_rate=None)
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}, {}))
 
     def test_explicitly_set_target_frame_rate_is_not_substituted(self):
         assert frame_rate.FrameRate(25, 2) in codecs.FRAME_RATE_SUBSTITUTIONS.get(codecs.VideoCodec.MPEG_2.value, {})
@@ -522,12 +526,12 @@ class TestConversionValidation(TestCase):
         metadata = self.modify_metadata_with_passed_values("mov", [1920, 1080], "mpeg2video", "aac", frame_rate=30)
         dst_params = self.create_params("mov", [1920, 1080], "mpeg2video", "aac", frame_rate='25/2')
         with self.assertRaises(exceptions.InvalidFrameRate):
-            self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}))
+            self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}, {}))
 
     def test_target_frame_rate_not_specified(self):
         metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "aac", frame_rate=60)
         dst_params = self.create_params("mp4", [1920, 1080], "h264", "aac", frame_rate=None)
-        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}))
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}, {}))
 
     @parameterized.expand(
         [
@@ -652,6 +656,7 @@ class TestConversionValidation(TestCase):
             dst_params,
             metadata,
             dst_muxer_info={},
+            dst_audio_encoder_info={},
             strip_unsupported_data_streams=False,
             strip_unsupported_subtitle_streams=False,
         ))
@@ -680,6 +685,7 @@ class TestConversionValidation(TestCase):
                 dst_params,
                 metadata,
                 dst_muxer_info={},
+                dst_audio_encoder_info={},
                 strip_unsupported_data_streams=False,
                 strip_unsupported_subtitle_streams=False,
             )
@@ -701,6 +707,7 @@ class TestConversionValidation(TestCase):
                 dst_params,
                 metadata,
                 dst_muxer_info={},
+                dst_audio_encoder_info={},
                 strip_unsupported_data_streams=False,
                 strip_unsupported_subtitle_streams=False,
             )
@@ -779,3 +786,104 @@ class TestValidateUnsupportedStreams(TestCase):
                 strip_unsupported_subtitle_streams=False,
                 target_container=None,
             )
+
+
+class TestValidateAudioSampleRates(TestCase):
+
+    def test_should_allow_rates_supported_by_encoder_if_codec_does_not_change(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'audio', 'codec_name': 'mp3', 'sample_rate': 44100},
+            {'index': 1, 'codec_type': 'audio', 'codec_name': 'mp3', 'sample_rate': 48000},
+            {'index': 2, 'codec_type': 'audio', 'codec_name': 'mp3', 'sample_rate': 8000},
+        ]}
+        dst_encoder_info = {'sample_rates': {48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000}}
+
+        self.assertTrue(validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info))
+
+    def test_should_allow_rates_supported_by_encoder_if_codec_changes(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'audio', 'codec_name': 'aac', 'sample_rate': 44100},
+            {'index': 1, 'codec_type': 'audio', 'codec_name': 'amr_nb', 'sample_rate': 48000},
+            {'index': 2, 'codec_type': 'audio', 'codec_name': 'pcm_u8', 'sample_rate': 8000},
+        ]}
+        dst_encoder_info = {'sample_rates': {48000, 44100, 32000, 24000, 22050, 16000, 12000, 11025, 8000}}
+
+        self.assertTrue(validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info))
+
+    def test_should_not_allow_rates_unsupported_by_encoder_if_codec_does_not_change(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'audio', 'codec_name': 'mp3', 'sample_rate': 44100},
+            {'index': 1, 'codec_type': 'audio', 'codec_name': 'mp3', 'sample_rate': 48000},
+            {'index': 2, 'codec_type': 'audio', 'codec_name': 'mp3', 'sample_rate': 8000},
+        ]}
+        dst_encoder_info = {'sample_rates': {48000}}
+
+        with self.assertRaises(exceptions.UnsupportedSampleRate):
+            validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info)
+
+    def test_should_not_allow_rates_unsupported_by_encoder_if_codec_changes(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'audio', 'codec_name': 'aac', 'sample_rate': 44100},
+            {'index': 1, 'codec_type': 'audio', 'codec_name': 'amr_nb', 'sample_rate': 48000},
+            {'index': 2, 'codec_type': 'audio', 'codec_name': 'pcm_u8', 'sample_rate': 8000},
+        ]}
+        dst_encoder_info = {'sample_rates': {48000}}
+
+        with self.assertRaises(exceptions.UnsupportedSampleRate):
+            validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info)
+
+    def test_should_allow_videos_with_no_audio(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'video', 'codec_name': 'h264'},
+            {'index': 1, 'codec_type': 'subtitle', 'codec_name': 'subrip'},
+        ]}
+        dst_encoder_info = {'sample_rates': {48000}}
+
+        self.assertTrue(validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info))
+        self.assertTrue(validation.validate_audio_sample_rates({'streams': []}, 'mp3', dst_encoder_info))
+        self.assertTrue(validation.validate_audio_sample_rates(metadata, 'mp3', {'sample_rates': {}}))
+
+    def test_should_not_allow_anything_if_encoder_supports_no_sample_rates(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'audio', 'codec_name': 'mp3', 'sample_rate': 44100},
+        ]}
+        dst_encoder_info = {'sample_rates': {}}
+
+        with self.assertRaises(exceptions.UnsupportedSampleRate):
+            validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info)
+
+    def test_should_allow_everything_if_encoder_does_not_provide_information_about_sample_rates(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'audio', 'codec_name': 'mp3', 'sample_rate': 44100},
+        ]}
+        dst_encoder_info = {}
+
+        self.assertTrue(validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info))
+
+    def test_should_not_allow_files_with_unknown_sample_rate(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'audio', 'codec_name': 'aac'},
+        ]}
+        dst_encoder_info = {'sample_rates': {48000}}
+
+        with self.assertRaises(exceptions.UnsupportedSampleRate):
+            validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info)
+
+    def test_should_allow_files_with_unknown_sample_rate_if_encoder_does_not_provide_information_about_sample_rates(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'audio', 'codec_name': 'aac'},
+        ]}
+        dst_encoder_info = {}
+
+        self.assertTrue(validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info))
+
+    def test_should_not_confuse_audio_with_other_types_of_streams(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'video', 'codec_name': 'aac', 'sample_rate': 44100},
+            {'index': 1, 'codec_type': 'subtitle', 'codec_name': 'aac', 'sample_rate': 48000},
+            {'index': 2, 'codec_type': 'data', 'codec_name': 'aac', 'sample_rate': 8000},
+            {'index': 3, 'codec_name': 'aac', 'sample_rate': 8000},
+        ]}
+        dst_encoder_info = {'aac': {22000}}
+
+        self.assertTrue(validation.validate_audio_sample_rates(metadata, 'aac', dst_encoder_info))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -329,6 +329,25 @@ class TestConversionValidation(TestCase):
             self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info, dst_audio_encoder_info))
 
 
+    def test_validate_transcoding_params_should_not_reject_sample_rate_if_audio_encoder_info_not_available(self):
+        metadata = self.modify_metadata_for_sample_rate_validation_tests("webm", "vp8", [
+            ('opus', 5000),
+        ])
+        dst_params = self.create_params("mp4", [640, 480], "h264", "aac")
+
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}, None))
+
+
+    def test_validate_transcoding_params_should_not_reject_sample_rate_if_audio_codec_not_specified_and_muxer_info_not_available(self):
+        metadata = self.modify_metadata_for_sample_rate_validation_tests("webm", "vp8", [
+            ('opus', 5000),
+        ])
+        dst_params = self.create_params("mp4", [640, 480], "h264")
+        dst_audio_encoder_info = {'sample_rates': [8000]}
+
+        self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, None, dst_audio_encoder_info))
+
+
     def test_container_change(self):
         metadata = self.modify_metadata_with_passed_values("mp4", [1920, 1080], "h264", "mp3", 60)
         dst_params = self.create_params("mov", [1920, 1080], "h264", "mp3", 60)
@@ -857,6 +876,14 @@ class TestValidateAudioSampleRates(TestCase):
             {'index': 0, 'codec_type': 'audio', 'codec_name': 'mp3', 'sample_rate': 44100},
         ]}
         dst_encoder_info = {}
+
+        self.assertTrue(validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info))
+
+    def test_should_allow_everything_if_encoder_info_is_not_available_at_all(self):
+        metadata = {'streams': [
+            {'index': 0, 'codec_type': 'audio', 'codec_name': 'mp3', 'sample_rate': 44100},
+        ]}
+        dst_encoder_info = None
 
         self.assertTrue(validation.validate_audio_sample_rates(metadata, 'mp3', dst_encoder_info))
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -251,7 +251,7 @@ class TestConversionValidation(TestCase):
         return metadata
 
 
-    @mock.patch('ffmpeg_tools.validation.meta.get_sample_rates', return_value=['48000', '24000'])
+    @mock.patch('ffmpeg_tools.validation.meta.get_sample_rates', return_value=[48000, 24000])
     def test_target_audio_codec_supports_source_sample_rates(self, _mock_get_sample_rates):
         metadata = self.modify_metadata_with_passed_values("mp4", [640, 480], "h264", "mp3", 60)
         dst_params = self.create_params("mp4", [640, 480], "h264", "mp3", 60)
@@ -259,7 +259,7 @@ class TestConversionValidation(TestCase):
         self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, {}))
 
 
-    @mock.patch('ffmpeg_tools.validation.meta.get_sample_rates', return_value=['48000', '24000'])
+    @mock.patch('ffmpeg_tools.validation.meta.get_sample_rates', return_value=[48000, 24000])
     def test_default_target_audio_codec_supports_source_sample_rate(self, _mock_get_sample_rates):
         metadata = self.modify_metadata_with_passed_values("mp4", [640, 480], "h264", "mp3", 60)
         dst_params = self.create_params("mp4", [640, 480], "h264")
@@ -268,7 +268,7 @@ class TestConversionValidation(TestCase):
         self.assertTrue(validation.validate_transcoding_params(dst_params, metadata, dst_muxer_info))
 
 
-    @mock.patch('ffmpeg_tools.validation.meta.get_sample_rates', return_value=['48000', '5000'])
+    @mock.patch('ffmpeg_tools.validation.meta.get_sample_rates', return_value=[48000, 5000])
     def test_target_audio_codec_does_not_support_source_sample_rate(self, _mock_get_sample_rates):
         metadata = self.modify_metadata_with_passed_values("mp4", [640, 480], "h264", "mp3", 60)
         dst_params = self.create_params("mp4", [640, 480], "h264", "mp3", 60)
@@ -277,7 +277,7 @@ class TestConversionValidation(TestCase):
             validation.validate_transcoding_params(dst_params, metadata, {})
 
 
-    @mock.patch('ffmpeg_tools.validation.meta.get_sample_rates', return_value=['48000', '5000'])
+    @mock.patch('ffmpeg_tools.validation.meta.get_sample_rates', return_value=[48000, 5000])
     def test_default_target_audio_codec_does_not_support_source_sample_rate(self, _mock_get_sample_rates):
         metadata = self.modify_metadata_with_passed_values("mp4", [640, 480], "h264", "mp3", 60)
         dst_params = self.create_params("mp4", [640, 480], "h264")


### PR DESCRIPTION
### Changes
1) This pull request adds a command that gets supported audio sample rates for a specific encoder from `ffmpeg -h` in a way similar to P5b in #23.
2) Just like in P5b, the command should be executed by the caller in an environment where ffmpeg is available and then the encoder info needs to be passed down to the validations.
3) Sample rates from `ffmpeg -h` must be integers. An exception is raised if they are not. The code is a bit more tolerant about sample rates obtained from the source file since they're going to be validated anyway and nothing is really certain about files you can find in the wild.
4) The branch also contains minor tweaks for the P5b regex.
5) `ffmpeg -h` unfortunately does not provide sample rates in all cases. The following encoders we support do not have this info: `libopencore_amrnb`, `ac3`, `libvorbis`, `wmav2`, `pcm_u8`. Here is a short summary of what I found out:
     - I tried to get more info from PyAV but it's simply not available and looking at libavcodec source confirms that ffmpeg does not have this info in a readily available form - for some codecs for various reasons the sample rate is validated but not stored in the encoder info struct. I played with test videos a bit and found out what the supported rates are but the bottom line is that if we want to validate according to this info, we have to hard-code it.
    - See #30 if you're interested in the details or raw results.

### API compatibility
`validate_transcoding_params()` has an extra, mandatory parameter (`dst_encoder_info`). Code calling that function must be updated.

### Dependencies
This pull request is based on #26 and depends on some of the changes introduced there so it should not be merged before it.

**NOTE**: I have set the base branch of this pull request to `task-o4-subtitle-format-conversion-when-possible` (#26). Please remember to change the base branch back to `master` before you merge.

### EDIT
Resolves #30.