### PR TITLE
Rename "format" field to "container" in params dict

### DIFF
--- a/ffmpeg_tools/meta.py
+++ b/ffmpeg_tools/meta.py
@@ -112,7 +112,7 @@ def get_attribute_from_all_streams(
 
 
 def create_params(
-    vformat,
+    container,
     resolution,
     vcodec,
     acodec=None,
@@ -124,7 +124,7 @@ def create_params(
 
     args = {}
 
-    args["format"] = vformat
+    args["container"] = container
 
     # Video parameters
     args["video"] = {}

--- a/ffmpeg_tools/validation.py
+++ b/ffmpeg_tools/validation.py
@@ -35,7 +35,7 @@ def _get_src_audio_codec(src_params):
 
 
 def _get_dst_audio_codec(dst_params: dict, dst_muxer_info: Optional[Dict[str, Any]]) -> Optional[str]:
-    assert not formats.Container(dst_params["format"]).is_exclusive_demuxer()
+    assert not formats.Container(dst_params["container"]).is_exclusive_demuxer()
 
     if dst_params.get("audio", {}).get("codec") is None:
         if dst_muxer_info is None:
@@ -88,12 +88,12 @@ def validate_transcoding_params(
         meta.get_frame_rate(src_metadata))
 
     # Validate format
-    validate_format(src_params["format"])
-    validate_target_format(dst_params["format"])
+    validate_format(src_params['container'])
+    validate_target_format(dst_params['container'])
 
     # Validate video codec
-    validate_video_codec(src_params["format"], src_params["video"]["codec"])
-    validate_video_codec(dst_params["format"], dst_params["video"]["codec"])
+    validate_video_codec(src_params['container'], src_params["video"]["codec"])
+    validate_video_codec(dst_params['container'], dst_params["video"]["codec"])
     validate_video_codec_conversion(src_params["video"]["codec"], dst_params["video"]["codec"])
 
     # Validate audio codec. Audio codec can not be set and ffmpeg should
@@ -103,11 +103,11 @@ def validate_transcoding_params(
     audio_stream = meta.get_audio_stream(src_metadata)
 
     if src_audio_codec is not None:
-        validate_audio_codec(src_params["format"], src_audio_codec)
+        validate_audio_codec(src_params["container"], src_audio_codec)
 
         dest_audio_codec = _get_dst_audio_codec(dst_params, dst_muxer_info)
         if dest_audio_codec is not None:
-            validate_audio_codec(dst_params["format"], dest_audio_codec)
+            validate_audio_codec(dst_params["container"], dest_audio_codec)
             validate_audio_codec_conversion(
                 src_audio_codec,
                 dest_audio_codec,
@@ -135,7 +135,7 @@ def validate_transcoding_params(
     validate_unsupported_subtitle_streams(
         src_metadata,
         strip_unsupported_subtitle_streams,
-        dst_params['format'])
+        dst_params['container'])
     return True
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ tests_require = [
 
 setuptools.setup(
     name='ffmpeg-tools',
-    version='0.18.0',
+    version='0.19.0',
     description="Tools for using ffmpeg functionalities in python.",
     url='https://github.com/golemfactory/ffmpeg-tools',
     maintainer='The Golem Team',


### PR DESCRIPTION
This is a minor change, somewhat related to https://github.com/golemfactory/golem/pull/4953 on Golem side but affects a different dict. Let's use `container` consistently everywhere, at least for dict fields.

### API compatibility
The structure of the dict returned from `meta.create_params()` is slightly different but this does not matter unless the caller is actually making looking into the contents of this dict, which normally is not necessary.

### Dependencies
This pull request is based on #27 but does not depend on changes introduced there and could be easily rebased.

**NOTE**: I have set the base branch of this pull request to `task-p6b-audio-sample-rate-validation` (#27). Please remember to change the base branch back to `master` before you merge.